### PR TITLE
Adding tr() for translation. Please always use tr()..

### DIFF
--- a/src/UI/dlgnewcontact.cpp
+++ b/src/UI/dlgnewcontact.cpp
@@ -46,7 +46,7 @@ void MTDlgNewContact::showEvent(QShowEvent * event)
 
         ui->frame->setLayout(m_pIdLayout);
         // --------------------------------------------------
-        m_pIdWidget->SetLabel("Paste or Scan QR Code: ");
+        m_pIdWidget->SetLabel(tr("Paste or Scan QR Code: "));
     } // first run.
     // -------------------------------------
     // call inherited method

--- a/src/Widgets/accountdetails.cpp
+++ b/src/Widgets/accountdetails.cpp
@@ -115,7 +115,7 @@ QWidget * MTAccountDetails::CreateCustomTab(int nTab)
         pGridLayout->setAlignment(Qt::AlignTop);
         // -----------------------------------------------------------
         {
-            QLabel    * pLabel          = new QLabel(QString("Account Name: "));
+            QLabel    * pLabel          = new QLabel(tr("Account Name: "));
 
             m_pLineEdit_Acct_ID         = new QLineEdit;
             m_pLineEdit_Acct_Name       = new QLineEdit;
@@ -132,7 +132,7 @@ QWidget * MTAccountDetails::CreateCustomTab(int nTab)
         }
         // -----------------------------------------------------------
         {
-            QLabel    * pLabel          = new QLabel(QString("Asset Type: "));
+            QLabel    * pLabel          = new QLabel(tr("Asset Type: "));
 
             m_pLineEdit_AssetType_ID    = new QLineEdit;
             m_pLineEdit_AssetType_Name  = new QLineEdit;
@@ -149,7 +149,7 @@ QWidget * MTAccountDetails::CreateCustomTab(int nTab)
         }
         // -----------------------------------------------------------
         {
-            QLabel    * pLabel          = new QLabel(QString("Owner Nym: "));
+            QLabel    * pLabel          = new QLabel(tr("Owner Nym: "));
 
             m_pLineEdit_Nym_ID          = new QLineEdit;
             m_pLineEdit_Nym_Name        = new QLineEdit;
@@ -166,7 +166,7 @@ QWidget * MTAccountDetails::CreateCustomTab(int nTab)
         }
         // -----------------------------------------------------------
         {
-            QLabel    * pLabel          = new QLabel(QString("Server: "));
+            QLabel    * pLabel          = new QLabel(tr("Server: "));
 
             m_pLineEdit_Server_ID       = new QLineEdit;
             m_pLineEdit_Server_Name     = new QLineEdit;
@@ -202,7 +202,7 @@ QString  MTAccountDetails::GetCustomTabName(int nTab)
     const int nCustomTabCount = this->GetCustomTabCount();
     // -----------------------------
     if ((nTab < 0) || (nTab >= nCustomTabCount))
-        return QString(""); // out of bounds.
+        return tr(""); // out of bounds.
     // -----------------------------
     QString qstrReturnValue("");
     // -----------------------------
@@ -212,7 +212,7 @@ QString  MTAccountDetails::GetCustomTabName(int nTab)
 
     default:
         qDebug() << QString("Unexpected: MTAccountDetails::GetCustomTabName was called with bad index: %1").arg(nTab);
-        return QString("");
+        return tr("");
     }
     // -----------------------------
     return qstrReturnValue;
@@ -325,8 +325,8 @@ void MTAccountDetails::DeleteButtonClicked()
 
         if (!bCanRemove)
         {
-            QMessageBox::warning(this, QString("Account Cannot Be Deleted"),
-                                 QString("This Account cannot be deleted yet, since it probably doesn't have a zero balance, "
+            QMessageBox::warning(this, tr("Account Cannot Be Deleted"),
+                                 tr("This Account cannot be deleted yet, since it probably doesn't have a zero balance, "
                                          "and probably still has outstanding receipts. (This is where, in the future, "
                                          "you will be given the option to automatically close-out all that stuff and thus delete "
                                          "this Account.)"));
@@ -335,7 +335,7 @@ void MTAccountDetails::DeleteButtonClicked()
         // ----------------------------------------------------
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "Are you sure you want to delete this Account?",
+        reply = QMessageBox::question(this, "", tr("Are you sure you want to delete this Account?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::Yes)
         {
@@ -352,8 +352,8 @@ void MTAccountDetails::DeleteButtonClicked()
                 m_pOwner->RefreshRecords();
             }
             else
-                QMessageBox::warning(this, QString("Failure Deleting Account"),
-                                     QString("Failed trying to delete this Account."));
+                QMessageBox::warning(this, tr("Failure Deleting Account"),
+                                     tr("Failed trying to delete this Account."));
         }
     }
     // ----------------------------------------------------

--- a/src/Widgets/assetdetails.cpp
+++ b/src/Widgets/assetdetails.cpp
@@ -76,8 +76,8 @@ void MTAssetDetails::DeleteButtonClicked()
 
         if (!bCanRemove)
         {
-            QMessageBox::warning(this, QString("Asset Contract Cannot Be Removed"),
-                                 QString("This Asset Contract cannot be removed, since you probably have already created accounts "
+            QMessageBox::warning(this, tr("Asset Contract Cannot Be Removed"),
+                                 tr("This Asset Contract cannot be removed, since you probably have already created accounts "
                                          "using this asset type. (This is where, in the future, you would be given the option "
                                          "to automatically delete those accounts, and remove this asset contract along with them.)"));
             return;
@@ -85,7 +85,7 @@ void MTAssetDetails::DeleteButtonClicked()
         // ----------------------------------------------------
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "Are you sure you want to delete this Asset Contract?",
+        reply = QMessageBox::question(this, "", tr("Are you sure you want to delete this Asset Contract?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::Yes)
         {
@@ -97,8 +97,8 @@ void MTAssetDetails::DeleteButtonClicked()
                 m_pOwner->RefreshRecords();
             }
             else
-                QMessageBox::warning(this, QString("Failure Removing Asset Contract"),
-                                     QString("Failed trying to remove this Asset Contract."));
+                QMessageBox::warning(this, tr("Failure Removing Asset Contract"),
+                                     tr("Failed trying to remove this Asset Contract."));
         }
     }
     // ----------------------------------------------------

--- a/src/Widgets/compose.cpp
+++ b/src/Widgets/compose.cpp
@@ -34,10 +34,10 @@ bool MTCompose::sendMessage(QString body, QString fromNymId, QString toNymId, QS
     }
     // ----------------------------------------------------
     if (subject.isEmpty())
-        subject = QString("From the desktop client. (Empty subject.)");
+        subject = tr("From the desktop client. (Empty subject.)");
     // ----------------------------------------------------
     if (body.isEmpty())
-        body = QString("From the desktop client. (Empty message body.)");
+        body = tr("From the desktop client. (Empty message body.)");
     // ----------------------------------------------------
     std::string str_serverId  (atServerID.toStdString());
     std::string str_fromNymId (fromNymId.toStdString());
@@ -46,7 +46,7 @@ bool MTCompose::sendMessage(QString body, QString fromNymId, QString toNymId, QS
     qDebug() << QString("Initiating sendMessage:\n Server:'%1'\n FromNym:'%2'\n ToNym:'%3'\n Subject:'%4'\n Body:'%5'").
                 arg(atServerID).arg(fromNymId).arg(toNymId).arg(subject).arg(body);
     // ----------------------------------------------------
-    QString contents = QString("Subject: %1\n\n%2").arg(subject).arg(body);
+    QString contents = tr("Subject: %1\n\n%2").arg(subject).arg(body);
     // ----------------------------------------------------
     OT_ME madeEasy;
 
@@ -71,22 +71,22 @@ void MTCompose::on_sendButton_clicked()
     // -----------------------------------------------------------------
     if (m_recipientNymId.isEmpty())
     {
-        QMessageBox::warning(this, QString("Message Has No Recipient"),
-                             QString("Please choose a recipient for this message, before sending."));
+        QMessageBox::warning(this, tr("Message Has No Recipient"),
+                             tr("Please choose a recipient for this message, before sending."));
         return;
     }
     // -----------------------------------------------------------------
     if (m_senderNymId.isEmpty())
     {
-        QMessageBox::warning(this, QString("Message Has No Sender"),
-                             QString("Please choose a sender for this message, before sending."));
+        QMessageBox::warning(this, tr("Message Has No Sender"),
+                             tr("Please choose a sender for this message, before sending."));
         return;
     }
     // -----------------------------------------------------------------
     if (m_serverId.isEmpty())
     {
-        QMessageBox::warning(this, QString("Message Has No Server"),
-                             QString("Before sending, please choose a server for this message to be sent through."));
+        QMessageBox::warning(this, tr("Message Has No Server"),
+                             tr("Before sending, please choose a server for this message to be sent through."));
         return;
     }
     // -----------------------------------------------------------------
@@ -94,7 +94,7 @@ void MTCompose::on_sendButton_clicked()
     {
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "This message has a blank subject. Are you sure you want to send?",
+        reply = QMessageBox::question(this, "", tr("This message has a blank subject. Are you sure you want to send?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::No)
           return;
@@ -104,7 +104,7 @@ void MTCompose::on_sendButton_clicked()
     {
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "The message contents are blank. Are you sure you want to send?",
+        reply = QMessageBox::question(this, "", tr("The message contents are blank. Are you sure you want to send?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::No)
           return;
@@ -126,8 +126,8 @@ void MTCompose::on_sendButton_clicked()
     }
     // -----------------------------------------------------------------
     if (!bSent)
-        QMessageBox::warning(this, QString("Failed Sending Message"),
-                             QString("Failed trying to send the message."));
+        QMessageBox::warning(this, tr("Failed Sending Message"),
+                             tr("Failed trying to send the message."));
     else
         this->close();
     // -----------------------------------------------------------------
@@ -205,7 +205,7 @@ void MTCompose::on_serverButton_clicked()
             m_serverId = theChooser.m_qstrCurrentID;
             // -----------------------------------------
             if (theChooser.m_qstrCurrentName.isEmpty())
-                ui->serverButton->setText(QString("(This server has a blank name)"));
+                ui->serverButton->setText(tr("(This server has a blank name)"));
             else
                 ui->serverButton->setText(theChooser.m_qstrCurrentName);
             // -----------------------------------------
@@ -218,7 +218,7 @@ void MTCompose::on_serverButton_clicked()
     }
     // -----------------------------------------------
     m_serverId = QString("");
-    ui->serverButton->setText("<Click to choose an OT Server>");
+    ui->serverButton->setText(tr("<Click to choose an OT Server>"));
 }
 
 void MTCompose::on_fromButton_clicked()
@@ -255,7 +255,7 @@ void MTCompose::on_fromButton_clicked()
     if (bFoundDefault && !m_senderNymId.isEmpty())
         theChooser.SetPreSelected(m_senderNymId);
     // -----------------------------------------------
-    theChooser.setWindowTitle("Choose your Sender identity");
+    theChooser.setWindowTitle(tr("Choose your Sender identity"));
     // -----------------------------------------------
     if (theChooser.exec() == QDialog::Accepted)
     {
@@ -279,7 +279,7 @@ void MTCompose::on_fromButton_clicked()
     }
     // -----------------------------------------------
     m_senderNymId = QString("");
-    ui->fromButton->setText("<Click to choose Sender>");
+    ui->fromButton->setText(tr("<Click to choose Sender>"));
 }
 
 
@@ -328,7 +328,7 @@ void MTCompose::on_toButton_clicked()
             {
                 qstrContactName  = QString("");
                 m_recipientNymId = QString("");
-                ui->toButton->setText("<Click to Choose Recipient>");
+                ui->toButton->setText(tr("<Click to Choose Recipient>"));
                 return;
             }
             // else...
@@ -336,7 +336,7 @@ void MTCompose::on_toButton_clicked()
             qstrContactName = MTContactHandler::getInstance()->GetContactName(nSelectedContactID);
 
             if (qstrContactName.isEmpty())
-                ui->toButton->setText("(Contact has a blank name)");
+                ui->toButton->setText(tr("(Contact has a blank name)"));
             else
                 ui->toButton->setText(qstrContactName);
             // ---------------------------------------------
@@ -360,10 +360,10 @@ void MTCompose::on_toButton_clicked()
                     else
                     {
                         m_recipientNymId = QString("");
-                        ui->toButton->setText("<Click to Choose Recipient>");
+                        ui->toButton->setText(tr("<Click to Choose Recipient>"));
                         // -------------------------------------
-                        QMessageBox::warning(this, QString("Contact has no known identities"),
-                                             QString("Sorry, Contact '%1' has no known NymIDs (to send messages to.)").arg(qstrContactName));
+                        QMessageBox::warning(this, tr("Contact has no known identities"),
+                                             tr("Sorry, Contact '%1' has no known NymIDs (to send messages to.)").arg(qstrContactName));
                         return;
                     }
                 }
@@ -371,24 +371,24 @@ void MTCompose::on_toButton_clicked()
                 {
                     DlgChooser theNymChooser(this);
                     theNymChooser.m_map = theNymMap;
-                    theNymChooser.setWindowTitle("Recipient has multiple Nyms. (Please choose one.)");
+                    theNymChooser.setWindowTitle(tr("Recipient has multiple Nyms. (Please choose one.)"));
                     // -----------------------------------------------
                     if (theNymChooser.exec() == QDialog::Accepted)
                         m_recipientNymId = theNymChooser.m_qstrCurrentID;
                     else // User must have cancelled.
                     {
                         m_recipientNymId = QString("");
-                        ui->toButton->setText("<Click to Choose Recipient>");
+                        ui->toButton->setText(tr("<Click to Choose Recipient>"));
                     }
                 }
             }
             else // No nyms found for this ContactID.
             {
                 m_recipientNymId = QString("");
-                ui->toButton->setText("<Click to Choose Recipient>");
+                ui->toButton->setText(tr("<Click to Choose Recipient>"));
                 // -------------------------------------
-                QMessageBox::warning(this, QString("Contact has no known identities"),
-                                     QString("Sorry, Contact '%1' has no known NymIDs (to send messages to.)").arg(qstrContactName));
+                QMessageBox::warning(this, tr("Contact has no known identities"),
+                                     tr("Sorry, Contact '%1' has no known NymIDs (to send messages to.)").arg(qstrContactName));
                 return;
             }
             // --------------------------------
@@ -410,7 +410,7 @@ void MTCompose::dialog()
 
     if (!already_init)
     {
-        this->setWindowTitle("Compose: (no subject)");
+        this->setWindowTitle(tr("Compose: (no subject)"));
 
         QString style_sheet = "QPushButton{border: none; border-style: outset; text-align:left; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,stop: 0 #dadbde, stop: 1 #f6f7fa);}"
                 "QPushButton:pressed {border: 1px solid black; text-align:left; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,stop: 0 #dadbde, stop: 1 #f6f7fa); }"
@@ -463,7 +463,7 @@ void MTCompose::dialog()
         if (str_sender_name.empty())
         {
             m_senderNymId = QString("");
-            ui->fromButton->setText(QString("<Click to Choose Sender>"));
+            ui->fromButton->setText(tr("<Click to Choose Sender>"));
         }
         else
             ui->fromButton->setText(QString::fromStdString(str_sender_name));
@@ -486,7 +486,7 @@ void MTCompose::dialog()
         if (str_recipient_name.empty())
         {
             m_recipientNymId = QString("");
-            ui->toButton->setText("<Click to Choose Recipient>");
+            ui->toButton->setText(tr("<Click to Choose Recipient>"));
         }
         else
             ui->toButton->setText(QString::fromStdString(str_recipient_name));
@@ -507,7 +507,7 @@ void MTCompose::dialog()
         if (str_server_name.empty())
         {
             m_serverId = QString("");
-            ui->serverButton->setText(QString("<Click to Choose Server>"));
+            ui->serverButton->setText(tr("<Click to Choose Server>"));
         }
         else
             ui->serverButton->setText(QString::fromStdString(str_server_name));
@@ -521,10 +521,11 @@ void MTCompose::dialog()
         {
             QString qstrRe = m_subject.left(4);
 
-            if ((qstrRe.toLower() != QString("re: ")) &&
-                (qstrRe.toLower() != QString("\"re:")))
+            if ((qstrRe.toLower() != tr("re: ")) &&
+                (qstrRe.toLower() != QString("\%1").arg(tr("re:")))
+               )
             {
-                QString strTemp = QString("re: %1").arg(m_subject);
+                QString strTemp = tr("re: %1").arg(m_subject);
                 m_subject = strTemp;
             }
             // -----------------------
@@ -532,7 +533,7 @@ void MTCompose::dialog()
 
             ui->subjectEdit->setText(qstrTempSubject);
             // -----------------------
-            this->setWindowTitle(QString("Compose: %1").arg(qstrTempSubject));
+            this->setWindowTitle(tr("Compose: %1").arg(qstrTempSubject));
         }
         // -------------------------------------------
 
@@ -555,7 +556,7 @@ void MTCompose::closeEvent(QCloseEvent *event)
     {
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "Are you sure you want to cancel this message?",
+        reply = QMessageBox::question(this, "", tr("Are you sure you want to cancel this message?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply != QMessageBox::Yes)
         {
@@ -604,11 +605,11 @@ void MTCompose::on_subjectEdit_textChanged(const QString &arg1)
     if (arg1.isEmpty())
     {
         m_subject = QString("");
-        this->setWindowTitle(QString("Compose: (no subject)"));
+        this->setWindowTitle(tr("Compose: (no subject)"));
     }
     else
     {
         m_subject = arg1;
-        this->setWindowTitle(QString("Compose: %1").arg(arg1));
+        this->setWindowTitle(tr("Compose: %1").arg(arg1));
     }
 }

--- a/src/Widgets/contactdetails.cpp
+++ b/src/Widgets/contactdetails.cpp
@@ -49,7 +49,7 @@ void MTContactDetails::AddButtonClicked()
     // -----------------------------------------------
     MTDlgNewContact theNewContact(this);
     // -----------------------------------------------
-    theNewContact.setWindowTitle("Create New Contact");
+    theNewContact.setWindowTitle(tr("Create New Contact"));
     // -----------------------------------------------
     if (theNewContact.exec() == QDialog::Accepted)
     {
@@ -68,8 +68,8 @@ void MTContactDetails::AddButtonClicked()
             {
                 QString contactName = MTContactHandler::getInstance()->GetContactName(nExisting);
 
-                QMessageBox::warning(this, QString("Contact Already Exists"),
-                                     QString("Contact '%1' already exists with NymID: %2").arg(contactName).arg(nymID));
+                QMessageBox::warning(this, tr("Contact Already Exists"),
+                                     tr("Contact '%1' already exists with NymID: %2").arg(contactName).arg(nymID));
                 return;
             }
             // -------------------------------------------------------
@@ -79,8 +79,8 @@ void MTContactDetails::AddButtonClicked()
 
             if (nContact <= 0)
             {
-                QMessageBox::warning(this, QString("Failed creating contact"),
-                                     QString("Failed trying to create contact for NymID: %1").arg(nymID));
+                QMessageBox::warning(this, tr("Failed creating contact"),
+                                     tr("Failed trying to create contact for NymID: %1").arg(nymID));
                 return;
             }
             // -------------------------------------------------------
@@ -122,7 +122,7 @@ void MTContactDetails::refresh(QString strID, QString strName)
 
         if (MTContactHandler::getInstance()->GetNyms(theNymMap, nContactID))
         {
-            strDetails += QString("Nyms:\n");
+            strDetails += tr("Nyms:\n");
 
             for (mapIDName::iterator ii = theNymMap.begin(); ii != theNymMap.end(); ii++)
             {
@@ -135,7 +135,7 @@ void MTContactDetails::refresh(QString strID, QString strName)
 
                 if (MTContactHandler::getInstance()->GetServers(theServerMap, qstrNymID))
                 {
-                    strDetails += QString("Found on servers:\n");
+                    strDetails += tr("Found on servers:\n");
 
                     for (mapIDName::iterator iii = theServerMap.begin(); iii != theServerMap.end(); iii++)
                     {
@@ -148,7 +148,7 @@ void MTContactDetails::refresh(QString strID, QString strName)
 
                         if (MTContactHandler::getInstance()->GetAccounts(theAccountMap, qstrNymID, qstrServerID, QString("")))
                         {
-                            strDetails += QString("Where he owns the accounts:\n");
+                            strDetails += tr("Where he owns the accounts:\n");
 
                             for (mapIDName::iterator iiii = theAccountMap.begin(); iiii != theAccountMap.end(); iiii++)
                             {

--- a/src/Widgets/depositwindow.cpp
+++ b/src/Widgets/depositwindow.cpp
@@ -12,7 +12,7 @@ void DepositWindow::dialog()
     {
         //Init deposit, then show.
         deposit_dialog = new QDialog(0);
-        deposit_dialog->setWindowTitle("Deposit | Moneychanger");
+        deposit_dialog->setWindowTitle(tr("Deposit | Moneychanger"));
         deposit_dialog->installEventFilter(this);
         //Gridlayout
         deposit_gridlayout = new QGridLayout(0);
@@ -21,16 +21,16 @@ void DepositWindow::dialog()
         deposit_dialog->setLayout(deposit_gridlayout);
         
         //Label (header)
-        deposit_header_label = new QLabel("<h1>Deposit</h1>");
+        deposit_header_label = new QLabel(QString("<h1>%1</h1>").arg(tr("Deposit")));
         deposit_header_label->setAlignment(Qt::AlignRight);
         deposit_gridlayout->addWidget(deposit_header_label, 0,1, 1,1);
         //Label ("Into Account") (subheader)
-        deposit_account_header_label = new QLabel("<h3>Into Account</h3>");
+        deposit_account_header_label = new QLabel(QString("<h3>%1</h3>").arg(tr("Into Account")));
         deposit_account_header_label->setAlignment(Qt::AlignRight);
         deposit_gridlayout->addWidget(deposit_account_header_label, 1,1, 1,1);
         
         //Label ("Into Purse") (subheader)
-        deposit_purse_header_label = new QLabel("<h3>Into Purse</h3>");
+        deposit_purse_header_label = new QLabel(QString("<h3>%1</h3>").arg(tr("Into Purse")));
         deposit_purse_header_label->setAlignment(Qt::AlignRight);
         deposit_gridlayout->addWidget(deposit_purse_header_label, 1,1, 1,1);
         deposit_purse_header_label->hide();
@@ -40,8 +40,8 @@ void DepositWindow::dialog()
         deposit_type = new QComboBox(0);
         deposit_type->setStyleSheet("QComboBox{padding:1em;}");
         deposit_gridlayout->addWidget(deposit_type, 0,0, 1,1, Qt::AlignHCenter);
-        deposit_type->addItem("Deposit into your Account", QVariant(0));
-        deposit_type->addItem("Deposit into your Purse", QVariant(1));
+        deposit_type->addItem(tr("Deposit into your Account"), QVariant(0));
+        deposit_type->addItem(tr("Deposit into your Purse"), QVariant(1));
         //connect "update" to switching open depsoit account/purse screens.
         connect(deposit_type, SIGNAL(currentIndexChanged(int)), this, SLOT(deposit_type_changed_slot(int)));
         

--- a/src/Widgets/detailedit.cpp
+++ b/src/Widgets/detailedit.cpp
@@ -73,7 +73,7 @@ void MTDetailEdit::dialog(MTDetailEdit::DetailEditType theType)
         pTab1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         pTab1->setContentsMargins(5, 5, 5, 5);
         // ----------------------------------
-        m_pTabWidget->addTab(pTab1, QString("Details"));
+        m_pTabWidget->addTab(pTab1, tr("Details"));
         // -------------------------------------------
         // Instantiate m_pDetailPane to one of various types.
         //

--- a/src/Widgets/dlgchooser.cpp
+++ b/src/Widgets/dlgchooser.cpp
@@ -87,7 +87,7 @@ void DlgChooser::showEvent(QShowEvent * event)
             //Render row.
             //Header of row
             QString qstr_name = qstrValue;
-//          QString qstr_name = QString("NAME GOES HERE");
+//          QString qstr_name = tr("NAME GOES HERE");
 
             QLabel * header_of_row = new QLabel;
             QString header_of_row_string = QString("");
@@ -100,7 +100,7 @@ void DlgChooser::showEvent(QShowEvent * event)
             // -------------------------------------------
             // Amount (with currency tla)
             QLabel * currency_amount_label = new QLabel;
-//          QString currency_amount = QString("AMOUNT");
+//          QString currency_amount = tr("AMOUNT");
             QString currency_amount = QString("");
 
             currency_amount_label->setStyleSheet(QString("QLabel { color : %1; }").arg(QString("red")));
@@ -146,7 +146,7 @@ void DlgChooser::showEvent(QShowEvent * event)
             QLabel * row_content_status_label = new QLabel;
             QString row_content_status_string;
 
-//          row_content_status_string.append(QString("DESCRIPTION"));
+//          row_content_status_string.append(tr("DESCRIPTION"));
             row_content_status_string.append(QString(""));
             // -------------------------------------------
             //add string to label

--- a/src/Widgets/editdetails.cpp
+++ b/src/Widgets/editdetails.cpp
@@ -120,7 +120,7 @@ QWidget * MTEditDetails::CreateDetailHeaderWidget(QString strID, QString strName
     // -------------------------------------------
     //Render row.
     //Header of row
-//  QString tx_name = QString("Name goes here");
+//  QString tx_name = tr("Name goes here");
     QString tx_name = strName;
 
     if(tx_name.trimmed() == "")
@@ -145,7 +145,7 @@ QWidget * MTEditDetails::CreateDetailHeaderWidget(QString strID, QString strName
 
     currency_amount_label->setStyleSheet(QString("QLabel { color : %1; }").arg(strColor));
     // ----------------------------------------------------------------
-//  currency_amount = QString("amount goes here");
+//  currency_amount = tr("amount goes here");
     currency_amount = strAmount;
     // ----------------------------------------------------------------
     currency_amount_label->setText(currency_amount);
@@ -169,7 +169,7 @@ QWidget * MTEditDetails::CreateDetailHeaderWidget(QString strID, QString strName
 
 
     QLabel * row_content_date_label = new QLabel;
-//  QString row_content_date_label_string("Date goes here");
+//  QString row_content_date_label_string(tr("Date goes here"));
     QString row_content_date_label_string(strID);
 
     row_content_date_label->setStyleSheet("QLabel { color : grey; font-size:11pt;}");
@@ -179,7 +179,7 @@ QWidget * MTEditDetails::CreateDetailHeaderWidget(QString strID, QString strName
     // -------------------------------------------
     // Column two
     std::string str_desc = strStatus.toStdString();
-//  std::string str_desc("Description goes here");
+//  std::string str_desc(tr("Description goes here"));
     // ---------------------------------------
     //Status
     QLabel * row_content_status_label = new QLabel;

--- a/src/Widgets/home.cpp
+++ b/src/Widgets/home.cpp
@@ -395,7 +395,7 @@ QWidget * MTHome::CreateUserBarWidget()
     // -------------------------------------------
     if (qstr_acct_id.isEmpty())
     {
-        qstr_acct_name   = QString("(Default Account Isn't Set Yet)");
+        qstr_acct_name   = tr("(Default Account Isn't Set Yet)");
         // -----------------------------------
         qstr_acct_nym    = ((Moneychanger *)(this->parentWidget()))->get_default_nym_id();
         qstr_acct_server = ((Moneychanger *)(this->parentWidget()))->get_default_server_id();
@@ -419,14 +419,14 @@ QWidget * MTHome::CreateUserBarWidget()
                 arg(QString::fromStdString(str_acct_name)).arg(QString::fromStdString(str_asset_name));
     }
     // -------------------------------------------
-//  QString   tx_name = QString("My Acct        <small><font color=grey>(US Dollars)</font></small>");
+//  QString   tx_name = tr("My Acct        <small><font color=grey>(US Dollars)</font></small>");
     QString & tx_name = qstr_acct_name;
     // -------------------------------------------
     if(tx_name.trimmed() == "")
     {
         //Tx has no name
         tx_name.clear();
-        tx_name = "(Account Name is Blank)";
+        tx_name = tr("(Account Name is Blank)");
     }
     // -------------------------------------------
     QLabel * header_of_row = new QLabel;
@@ -480,26 +480,26 @@ QWidget * MTHome::CreateUserBarWidget()
     buttonSend->setAutoRaise(true);
     buttonSend->setIcon(sendButtonIcon);
     buttonSend->setIconSize(pixmapSend.rect().size());
-    buttonSend->setText("Send");
+    buttonSend->setText(tr("Send"));
     // ----------------------------------------------------------------
     buttonRequest->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     buttonRequest->setAutoRaise(true);
     buttonRequest->setIcon(requestButtonIcon);
     buttonRequest->setIconSize(pixmapRequest.rect().size());
-    buttonRequest->setText("Request");
+    buttonRequest->setText(tr("Request"));
     // ----------------------------------------------------------------
     buttonContacts->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     buttonContacts->setAutoRaise(true);
     buttonContacts->setIcon(contactsButtonIcon);
     buttonContacts->setIconSize(pixmapContacts.rect().size());
-    buttonContacts->setText("Contacts");
+    buttonContacts->setText(tr("Contacts"));
     // ----------------------------------------------------------------
     buttonRefresh->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     buttonRefresh->setAutoRaise(true);
     buttonRefresh->setIcon(refreshButtonIcon);
 //    buttonRefresh->setIconSize(pixmapRefresh.rect().size());
     buttonRefresh->setIconSize(pixmapContacts.rect().size());
-    buttonRefresh->setText("Refresh");
+    buttonRefresh->setText(tr("Refresh"));
 
     if (m_bNeedRefresh)
     {
@@ -542,14 +542,14 @@ QWidget * MTHome::CreateUserBarWidget()
     //Date (sub-info)
     //Calc/convert date/times
     //
-    QLabel * row_content_date_label = new QLabel("<font color=grey>Available:</font> (no account selected)");
+    QLabel * row_content_date_label = new QLabel(QString("<font color=grey>%1</font> %2").arg(tr("Available:")).arg(tr("no account selected")));
 //  QString  row_content_date_label_string("<font color=grey>Available:</font> $50.93 (+ $167.23 in cash)");
     // ---------------------------------------------
     QString  row_content_date_label_string = QString("");
 
     if (!qstr_acct_id.isEmpty())
     {
-        row_content_date_label_string = QString("<font color=grey>Available:</font> %1").arg(MTHome::shortAcctBalance(qstr_acct_id, qstr_acct_asset));
+        row_content_date_label_string = QString("<font color=grey>%1</font> %2").arg(tr("Available:")).arg(MTHome::shortAcctBalance(qstr_acct_id, qstr_acct_asset));
     }
     // --------------------------------------------
     if (!qstr_acct_nym.isEmpty() && !qstr_acct_server.isEmpty() && !qstr_acct_asset.isEmpty())
@@ -557,7 +557,7 @@ QWidget * MTHome::CreateUserBarWidget()
         int64_t  raw_cash_balance = this->rawCashBalance(qstr_acct_server, qstr_acct_asset, qstr_acct_nym);
 
         if (raw_cash_balance > 0)
-            row_content_date_label_string += QString(" (+ %1 in cash)").arg(cashBalance(qstr_acct_server, qstr_acct_asset, qstr_acct_nym));
+            row_content_date_label_string += QString(" (+ %1 in cash)").arg(cashBalance(qstr_acct_server, qstr_acct_asset, qstr_acct_nym)).arg(tr(" in cash"));
     }
     // ---------------------------------------------------------------
 //  row_content_date_label_string.append(QString(timestamp.toString(Qt::SystemLocaleShortDate)));

--- a/src/Widgets/homedetail.cpp
+++ b/src/Widgets/homedetail.cpp
@@ -225,7 +225,7 @@ void MTHomeDetail::on_existingContactButton_clicked(bool checked /*=false*/)
         // --------------------------------------------------
         if (str_nym_id.empty())
         {
-            QMessageBox::warning(this, QString("Failure"), QString("Sorry, but this record has no NymID."));
+            QMessageBox::warning(this, tr("Failure"), tr("Sorry, but this record has no NymID."));
             return;
         }
         // else...
@@ -237,8 +237,8 @@ void MTHomeDetail::on_existingContactButton_clicked(bool checked /*=false*/)
 
         if (MTContactHandler::getInstance()->ContactExists(nymID.toInt()))
         {
-            QMessageBox::warning(this, QString("Strange"),
-                                 QString("Strange: NymID %1 already belongs to an existing contact.").arg(nymID));
+            QMessageBox::warning(this, tr("Strange"),
+                                 tr("Strange: NymID %1 already belongs to an existing contact.").arg(nymID));
             return;
         }
         // --------------------------------------------------------------------
@@ -250,7 +250,7 @@ void MTHomeDetail::on_existingContactButton_clicked(bool checked /*=false*/)
         mapIDName & the_map = theChooser.m_map;
         MTContactHandler::getInstance()->GetContacts(the_map);
         // -----------------------------------------------
-        theChooser.setWindowTitle("Choose an Existing Contact");
+        theChooser.setWindowTitle(tr("Choose an Existing Contact"));
         // -----------------------------------------------
         if (theChooser.exec() == QDialog::Accepted)
         {
@@ -267,7 +267,7 @@ void MTHomeDetail::on_existingContactButton_clicked(bool checked /*=false*/)
                 if (!bAdded)
                 {
                     QString strContactName(MTContactHandler::getInstance()->GetContactName(nContactID));
-                    QMessageBox::warning(this, QString("Failure"), QString("Failed while trying to add NymID %1 to existing contact '%2' with contact ID: %3").
+                    QMessageBox::warning(this, tr("Failure"), QString("Failed while trying to add NymID %1 to existing contact '%2' with contact ID: %3").
                                          arg(nymID).arg(strContactName).arg(nContactID));
                     return;
                 }
@@ -312,7 +312,7 @@ void MTHomeDetail::on_deleteButton_clicked(bool checked /*=false*/)
     // --------------------------------
     QMessageBox::StandardButton reply;
 
-    reply = QMessageBox::question(this, "", "Are you sure you want to archive this record?",
+    reply = QMessageBox::question(this, "", tr("Are you sure you want to archive this record?"),
                                   QMessageBox::Yes|QMessageBox::No);
     if (reply == QMessageBox::No)
       return;
@@ -475,8 +475,8 @@ QString MTHomeDetail::FindAppropriateDepositAccount(MTRecord & recordmt)
         //
         if (0 == the_map.size())
         {
-            QMessageBox::warning(this, QString("No Matching Accounts"),
-                                 QString("There are no existing accounts with the proper asset type, server, and nym. "
+            QMessageBox::warning(this, tr("No Matching Accounts"),
+                                 tr("There are no existing accounts with the proper asset type, server, and nym. "
                                          "In the future, this is where you would be given the option to create "
                                          "one. (Someday.) In the meantime, just create one and then try again."));
             return QString("");
@@ -533,7 +533,7 @@ void MTHomeDetail::on_acceptButton_clicked(bool checked /*=false*/)
             // -----------------------------------------
             if (!bSuccess)
             {
-                QMessageBox::warning(this, QString("Transaction failure"), QString("Failed accepting this transfer."));
+                QMessageBox::warning(this, tr("Transaction failure"), tr("Failed accepting this transfer."));
             }
             else
             {
@@ -555,7 +555,7 @@ void MTHomeDetail::on_acceptButton_clicked(bool checked /*=false*/)
             // -----------------------------------------
             if (!bSuccess)
             {
-                QMessageBox::warning(this, QString("Transaction failure"), QString("Failed accepting this receipt."));
+                QMessageBox::warning(this, tr("Transaction failure"), tr("Failed accepting this receipt."));
             }
             else
             {
@@ -573,7 +573,7 @@ void MTHomeDetail::on_acceptButton_clicked(bool checked /*=false*/)
             {
                 QMessageBox::StandardButton reply;
 
-                reply = QMessageBox::question(this, "", "Are you sure you want to pay this invoice?",
+                reply = QMessageBox::question(this, "", tr("Are you sure you want to pay this invoice?"),
                                               QMessageBox::Yes|QMessageBox::No);
                 if (reply == QMessageBox::No)
                     return;
@@ -596,7 +596,7 @@ void MTHomeDetail::on_acceptButton_clicked(bool checked /*=false*/)
                 // -----------------------------------------
                 if (!bSuccess)
                 {
-                    QMessageBox::warning(this, QString("Transaction failure"), QString("Failed accepting this instrument."));
+                    QMessageBox::warning(this, tr("Transaction failure"), tr("Failed accepting this instrument."));
                 }
                 else
                 {
@@ -625,9 +625,9 @@ void MTHomeDetail::on_cancelButton_clicked(bool checked /*=false*/)
             QMessageBox::StandardButton reply;
 
             reply = QMessageBox::question(this, "",
-                                          "This will prevent the original recipient from depositing the cash. "
+                                          tr("This will prevent the original recipient from depositing the cash. "
                                           "(And FYI, this action will fail, if he has already deposited it.) "
-                                          "Are you sure you want to recover this cash?",
+                                          "Are you sure you want to recover this cash?"),
                                           QMessageBox::Yes|QMessageBox::No);
             if (reply == QMessageBox::No)
                 return;
@@ -656,8 +656,8 @@ void MTHomeDetail::on_cancelButton_clicked(bool checked /*=false*/)
                 // -----------------------------------------
                 if (!bSuccess)
                 {
-                    QMessageBox::warning(this, QString("Recovery failure"),
-                                         QString("Failed recovering this outgoing cash. "
+                    QMessageBox::warning(this, tr("Recovery failure"),
+                                         tr("Failed recovering this outgoing cash. "
                                                  "(Perhaps the recipient already deposited it?)"));
                 }
                 else
@@ -678,9 +678,9 @@ void MTHomeDetail::on_cancelButton_clicked(bool checked /*=false*/)
             QMessageBox::StandardButton reply;
 
             reply = QMessageBox::question(this, "",
-                                          "This will prevent the original recipient from exercising this instrument. "
+                                          tr("This will prevent the original recipient from exercising this instrument. "
                                           "(And FYI, this action will fail if he's already done so.) "
-                                          "Are you sure you want to cancel?",
+                                          "Are you sure you want to cancel?"),
                                           QMessageBox::Yes|QMessageBox::No);
             if (reply == QMessageBox::No)
                 return;
@@ -694,8 +694,8 @@ void MTHomeDetail::on_cancelButton_clicked(bool checked /*=false*/)
             // -----------------------------------------
             if (!bSuccess)
             {
-                QMessageBox::warning(this, QString("Cancellation failure"),
-                                     QString("Failed canceling this outgoing instrument."));
+                QMessageBox::warning(this, tr("Cancellation failure"),
+                                     tr("Failed canceling this outgoing instrument."));
             }
             else
             {
@@ -722,9 +722,9 @@ void MTHomeDetail::on_discardOutgoingButton_clicked(bool checked /*=false*/)
         QMessageBox::StandardButton reply;
 
         reply = QMessageBox::question(this, "",
-                                      "This will prevent you from recovering this cash in the future. "
+                                      tr("This will prevent you from recovering this cash in the future. "
                                       "(And FYI, once the cash expires, this record will be discarded automatically anyway.) "
-                                      "Are you sure you want to discard this record of sent cash?",
+                                      "Are you sure you want to discard this record of sent cash?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::No)
             return;
@@ -738,8 +738,8 @@ void MTHomeDetail::on_discardOutgoingButton_clicked(bool checked /*=false*/)
         // -----------------------------------------
         if (!bSuccess)
         {
-            QMessageBox::warning(this, QString("Discard failure"),
-                                 QString("Failed discarding this sent cash."));
+            QMessageBox::warning(this, tr("Discard failure"),
+                                 tr("Failed discarding this sent cash."));
         }
         else
         {
@@ -767,10 +767,10 @@ void MTHomeDetail::on_discardIncomingButton_clicked(bool checked /*=false*/)
         // ---------------------------------------
         QMessageBox::StandardButton reply;
 
-        QString qstr_instrument = recordmt.IsInvoice() ? QString("invoice") : QString("instrument");
+        QString qstr_instrument = recordmt.IsInvoice() ? tr("invoice") : tr("instrument");
 
         reply = QMessageBox::question(this, "",
-                                      QString("Are you sure you want to discard this incoming %1?").arg(qstr_instrument),
+                                      tr("Are you sure you want to discard this incoming %1?").arg(qstr_instrument),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::No)
             return;
@@ -784,8 +784,8 @@ void MTHomeDetail::on_discardIncomingButton_clicked(bool checked /*=false*/)
         // -----------------------------------------
         if (!bSuccess)
         {
-            QMessageBox::warning(this, QString("Discard failure"),
-                                 QString("Failed discarding this incoming %1.").arg(qstr_instrument));
+            QMessageBox::warning(this, tr("Discard failure"),
+                                 tr("Failed discarding this incoming %1.").arg(qstr_instrument));
         }
         else
         {
@@ -967,9 +967,9 @@ QWidget * MTHomeDetail::CreateDetailHeaderWidget(MTRecord & recordmt, bool bExte
     else if (recordmt.IsMail())
     {
         if (recordmt.IsOutgoing())
-            currency_amount = QString("sent msg");
+            currency_amount = tr("sent msg");
         else
-            currency_amount = QString("message");
+            currency_amount = tr("message");
         // ------------------------------------------
         if (!bExternal)
         {
@@ -1199,9 +1199,9 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
     QString viewDetails = QString("");
 
     if (recordmt.IsReceipt() || recordmt.IsOutgoing())
-        viewDetails = QString("View Recipient Details");
+        viewDetails = tr("View Recipient Details");
     else
-        viewDetails = QString("View Sender Details");
+        viewDetails = tr("View Sender Details");
     // --------------------------------------------------
     const std::string str_acct_id    = recordmt.GetOtherAccountID();
     const std::string str_nym_id     = recordmt.GetOtherNymID();
@@ -1239,7 +1239,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
     }
     else if (!str_nym_id.empty())
     {
-        QPushButton * addContactButton = new QPushButton(QString("Add as Contact"));
+        QPushButton * addContactButton = new QPushButton(tr("Add as Contact"));
 
         m_pDetailLayout->addWidget(addContactButton, nCurrentRow, nCurrentColumn,1,1);
         m_pDetailLayout->setAlignment(addContactButton, Qt::AlignTop);
@@ -1251,7 +1251,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
         // If the contact didn't already exist, we don't just have "add new contact"
         // but also "add to existing contact."
         //
-        QPushButton * existingContactButton = new QPushButton(QString("Add to an Existing Contact"));
+        QPushButton * existingContactButton = new QPushButton(tr("Add to an Existing Contact"));
 
         m_pDetailLayout->addWidget(existingContactButton, nCurrentRow, nCurrentColumn,1,1);
         m_pDetailLayout->setAlignment(existingContactButton, Qt::AlignTop);
@@ -1263,7 +1263,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
     // *************************************************************
     if (recordmt.CanDeleteRecord())
     {
-        QString deleteActionName = recordmt.IsMail() ? QString("Archive this Message") : QString("Archive this Record");
+        QString deleteActionName = recordmt.IsMail() ? tr("Archive this Message") : tr("Archive this Record");
         QPushButton * deleteButton = new QPushButton(deleteActionName);
 
         m_pDetailLayout->addWidget(deleteButton, nCurrentRow, nCurrentColumn,1,1);
@@ -1285,48 +1285,48 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
         if (recordmt.IsTransfer())
         {
-            nameString = QString("Accept this Transfer");
-            actionString = QString("Accepting...");
+            nameString = tr("Accept this Transfer");
+            actionString = tr("Accepting...");
         }
         else if (recordmt.IsReceipt())
         {
-            nameString = QString("Accept this Receipt");
-            actionString = QString("Accepting...");
+            nameString = tr("Accept this Receipt");
+            actionString = tr("Accepting...");
         }
         else if (recordmt.IsInvoice())
         {
-            nameString = QString("Pay this Invoice");
-            actionString = QString("Paying...");
+            nameString = tr("Pay this Invoice");
+            actionString = tr("Paying...");
         }
         else if (recordmt.IsPaymentPlan())
         {
-            nameString = QString("Activate this Payment Plan");
-            actionString = QString("Activating...");
+            nameString = tr("Activate this Payment Plan");
+            actionString = tr("Activating...");
         }
         else if (recordmt.IsContract())
         {
-            nameString = QString("Sign this Smart Contract");
-            actionString = QString("Signing...");
+            nameString = tr("Sign this Smart Contract");
+            actionString = tr("Signing...");
         }
         else if (recordmt.IsCash())
         {
-            nameString = QString("Deposit this Cash");
-            actionString = QString("Depositing...");
+            nameString = tr("Deposit this Cash");
+            actionString = tr("Depositing...");
         }
         else if (recordmt.IsCheque())
         {
-            nameString = QString("Deposit this Cheque");
-            actionString = QString("Depositing...");
+            nameString = tr("Deposit this Cheque");
+            actionString = tr("Depositing...");
         }
         else if (recordmt.IsVoucher())
         {
-            nameString = QString("Accept this Payment");
-            actionString = QString("Accepting...");
+            nameString = tr("Accept this Payment");
+            actionString = tr("Accepting...");
         }
         else
         {
-            nameString = QString("Deposit this Payment");
-            actionString = QString("Depositing...");
+            nameString = tr("Deposit this Payment");
+            actionString = tr("Depositing...");
         }
 
         QPushButton * acceptButton = new QPushButton(nameString);
@@ -1342,31 +1342,31 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (recordmt.CanCancelOutgoing())
     {
-        QString msg = QString("Cancellation Failed. Perhaps recipient had already accepted it?");
+        QString msg = tr("Cancellation Failed. Perhaps recipient had already accepted it?");
 //        UIAlertView *fail = [[UIAlertView alloc] initWithTitle:nil message:msg delegate:nil
 //                                             cancelButtonTitle:QString("OK") otherButtonTitles:nil];
 
         QString cancelString;
-        QString actionString = QString("Canceling...");
+        QString actionString = tr("Canceling...");
 
         if (recordmt.IsInvoice())
-            cancelString = QString("Cancel this Invoice");
+            cancelString = tr("Cancel this Invoice");
         else if (recordmt.IsPaymentPlan())
-            cancelString = QString("Cancel this Payment Plan");
+            cancelString = tr("Cancel this Payment Plan");
         else if (recordmt.IsContract())
-            cancelString = QString("Cancel this Smart Contract");
+            cancelString = tr("Cancel this Smart Contract");
         else if (recordmt.IsCash())
         {
-            cancelString = QString("Recover this Cash");
-            actionString = QString("Recovering...");
-            msg = QString("Recovery Failed. Perhaps recipient had already accepted it?");
+            cancelString = tr("Recover this Cash");
+            actionString = tr("Recovering...");
+            msg = tr("Recovery Failed. Perhaps recipient had already accepted it?");
         }
         else if (recordmt.IsCheque())
-            cancelString = QString("Cancel this Cheque");
+            cancelString = tr("Cancel this Cheque");
         else if (recordmt.IsVoucher())
-            cancelString = QString("Cancel this Payment");
+            cancelString = tr("Cancel this Payment");
         else
-            cancelString = QString("Cancel this Payment");
+            cancelString = tr("Cancel this Payment");
 
 
         QPushButton * cancelButton = new QPushButton(cancelString);
@@ -1382,7 +1382,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (recordmt.CanDiscardOutgoingCash())
     {
-        QString discardString = QString("Discard this Sent Cash");
+        QString discardString = tr("Discard this Sent Cash");
 
         QPushButton * discardOutgoingButton = new QPushButton(discardString);
 
@@ -1401,19 +1401,19 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
         QString discardString;
 
         if (recordmt.IsInvoice())
-            discardString = QString("Discard this Invoice");
+            discardString = tr("Discard this Invoice");
         else if (recordmt.IsPaymentPlan())
-            discardString = QString("Discard this Payment Plan");
+            discardString = tr("Discard this Payment Plan");
         else if (recordmt.IsContract())
-            discardString = QString("Discard this Smart Contract");
+            discardString = tr("Discard this Smart Contract");
         else if (recordmt.IsCash())
-            discardString = QString("Discard this Cash");
+            discardString = tr("Discard this Cash");
         else if (recordmt.IsCheque())
-            discardString = QString("Discard this Cheque");
+            discardString = tr("Discard this Cheque");
         else if (recordmt.IsVoucher())
-            discardString = QString("Discard this Payment");
+            discardString = tr("Discard this Payment");
         else
-            discardString = QString("Discard this Payment");
+            discardString = tr("Discard this Payment");
 
 
         QPushButton * discardIncomingButton = new QPushButton(discardString);
@@ -1432,12 +1432,12 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
         QString msgUser;
 
         if (recordmt.IsReceipt() || recordmt.IsOutgoing())
-            msgUser = QString("Message the Recipient");
+            msgUser = tr("Message the Recipient");
         else
-            msgUser = QString("Message the Sender");
+            msgUser = tr("Message the Sender");
 
 
-        QPushButton * msgButton = new QPushButton(((recordmt.IsMail() && !recordmt.IsOutgoing()) ? QString("Reply to this Message") : msgUser));
+        QPushButton * msgButton = new QPushButton(((recordmt.IsMail() && !recordmt.IsOutgoing()) ? tr("Reply to this Message") : msgUser));
 
         m_pDetailLayout->addWidget(msgButton, nCurrentRow, nCurrentColumn,1,1);
         m_pDetailLayout->setAlignment(msgButton, Qt::AlignTop);
@@ -1467,9 +1467,9 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
     QString qstr_OtherType;
 
     if (recordmt.IsReceipt() || recordmt.IsOutgoing())
-        qstr_OtherType = QString("Recipient");
+        qstr_OtherType = tr("Recipient");
     else
-        qstr_OtherType = QString("Sender");
+        qstr_OtherType = tr("Sender");
 
     QGridLayout * pGridLayout = new QGridLayout;
     int nGridRow = 0;
@@ -1484,7 +1484,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (!qstr_NymID.isEmpty())
     {
-        QLabel    * pLabel    = new QLabel(QString("My Nym: "));
+        QLabel    * pLabel    = new QLabel(tr("My Nym: "));
 
         MTNameLookupQT theLookup;
         QString qstr_name = QString::fromStdString(theLookup.GetNymName(qstr_NymID.toStdString()));
@@ -1505,7 +1505,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (!qstr_OtherNymID.isEmpty())
     {
-        QLabel    * pLabel    = new QLabel(QString("%1 Nym: ").arg(qstr_OtherType));
+        QLabel    * pLabel    = new QLabel(tr("%1 Nym: ").arg(qstr_OtherType));
 
         MTNameLookupQT theLookup;
         QString qstr_name = QString::fromStdString(theLookup.GetNymName(qstr_OtherNymID.toStdString()));
@@ -1526,7 +1526,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (!qstr_AccountID.isEmpty())
     {
-        QLabel    * pLabel    = new QLabel(QString("My Account: "));
+        QLabel    * pLabel    = new QLabel(tr("My Account: "));
 
         MTNameLookupQT theLookup;
         QString qstr_name = QString::fromStdString(theLookup.GetAcctName(qstr_AccountID.toStdString()));
@@ -1547,7 +1547,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (!qstr_OtherAcctID.isEmpty())
     {
-        QLabel    * pLabel    = new QLabel(QString("%1 Account: ").arg(qstr_OtherType));
+        QLabel    * pLabel    = new QLabel(tr("%1 Account: ").arg(qstr_OtherType));
 
         MTNameLookupQT theLookup;
         QString qstr_name = QString::fromStdString(theLookup.GetAcctName(qstr_OtherAcctID.toStdString()));
@@ -1568,7 +1568,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (!qstr_ServerID.isEmpty())
     {
-        QLabel    * pLabel    = new QLabel(QString("Server: "));
+        QLabel    * pLabel    = new QLabel(tr("Server: "));
 
         QString qstr_name = QString::fromStdString(OTAPI_Wrap::GetServer_Name(qstr_ServerID.toStdString()));
 
@@ -1588,7 +1588,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
 
     if (!qstr_AssetTypeID.isEmpty())
     {
-        QLabel    * pLabel    = new QLabel(QString("Asset Type: "));
+        QLabel    * pLabel    = new QLabel(tr("Asset Type: "));
 
         QString qstr_name = QString::fromStdString(OTAPI_Wrap::GetAssetType_Name(qstr_AssetTypeID.toStdString()));
 
@@ -1619,7 +1619,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
     pTabWidget->setContentsMargins(5, 5, 5, 5);
     pTab1Widget->setContentsMargins(5, 5, 5, 5);
 
-    pTabWidget->addTab(pTab1Widget, QString("Details"));
+    pTabWidget->addTab(pTab1Widget, tr("Details"));
     // ----------------------------------
     if (pGridLayout->count() > 0)
     {
@@ -1628,7 +1628,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
         pTab3Widget->setContentsMargins(0, 0, 0, 0);
         pTab3Widget->setLayout(pGridLayout);
 
-        pTabWidget->addTab(pTab3Widget, QString("IDs"));
+        pTabWidget->addTab(pTab3Widget, tr("IDs"));
 //      m_pDetailLayout->addLayout(pGridLayout, nCurrentRow++, nCurrentColumn, 1, 2, Qt::AlignBottom);
     }
     else
@@ -1670,7 +1670,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
         {
             pvBox       = new QVBoxLayout;
             pTab2Widget = new QWidget;
-            QLabel * pLabelContents = new QLabel(QString("Raw Contents:"));
+            QLabel * pLabelContents = new QLabel(tr("Raw Contents:"));
 
             pvBox->setAlignment(Qt::AlignTop);
             pvBox->addWidget   (pLabelContents);
@@ -1679,7 +1679,7 @@ void MTHomeDetail::refresh(MTRecord & recordmt)
             pTab2Widget->setContentsMargins(0, 0, 0, 0);
             pTab2Widget->setLayout(pvBox);
 
-            pTabWidget->addTab(pTab2Widget, QString("Contents"));
+            pTabWidget->addTab(pTab2Widget, tr("Contents"));
         }
         // -------------------------------
     }    

--- a/src/Widgets/marketwindow.cpp
+++ b/src/Widgets/marketwindow.cpp
@@ -16,7 +16,7 @@ MarketWindow::~MarketWindow()
 
 void MarketWindow::on_pushButton_clicked()
 {
-    ui->textEdit->setText("Test Success!");
+    ui->textEdit->setText(tr("Test Success!"));
 }
 
 void MarketWindow::on_pushButton_2_clicked()

--- a/src/Widgets/nymdetails.cpp
+++ b/src/Widgets/nymdetails.cpp
@@ -60,7 +60,7 @@ QWidget * MTNymDetails::CreateCustomTab(int nTab)
         // -------------------------------
         QVBoxLayout * pvBox = new QVBoxLayout;
 
-        QLabel * pLabelContents = new QLabel(QString("Raw State of Nym:"));
+        QLabel * pLabelContents = new QLabel(tr("Raw State of Nym:"));
 
         pvBox->setAlignment(Qt::AlignTop);
         pvBox->addWidget   (pLabelContents);
@@ -177,8 +177,8 @@ void MTNymDetails::DeleteButtonClicked()
 
         if (!bCanRemove)
         {
-            QMessageBox::warning(this, QString("Nym Cannot Be Deleted"),
-                                 QString("This Nym cannot be deleted yet, since it's already been registered on at least one "
+            QMessageBox::warning(this, tr("Nym Cannot Be Deleted"),
+                                 tr("This Nym cannot be deleted yet, since it's already been registered on at least one "
                                          "server, and perhaps even owns an asset account or two. (This is where, in the future, "
                                          "you will be given the option to automatically delete all that stuff and thus delete "
                                          "this Nym.)"));
@@ -199,8 +199,8 @@ void MTNymDetails::DeleteButtonClicked()
                 m_pOwner->RefreshRecords();
             }
             else
-                QMessageBox::warning(this, QString("Failure Deleting Nym"),
-                                     QString("Failed trying to delete this Nym."));
+                QMessageBox::warning(this, tr("Failure Deleting Nym"),
+                                     tr("Failed trying to delete this Nym."));
         }
     }
     // ----------------------------------------------------

--- a/src/Widgets/overviewwindow.cpp
+++ b/src/Widgets/overviewwindow.cpp
@@ -21,7 +21,7 @@ void OverviewWindow::dialog()
         //The overview dialog has not been init yet; Init, then show it.
         mc_overview_dialog_page = new QDialog(0);
         mc_overview_dialog_page->setWindowFlags(Qt::WindowStaysOnTopHint);
-        mc_overview_dialog_page->setWindowTitle("Overview | Moneychanger");
+        mc_overview_dialog_page->setWindowTitle(tr("Overview | Moneychanger"));
         
         mc_overview_dialog_page->installEventFilter(this);
 
@@ -30,7 +30,7 @@ void OverviewWindow::dialog()
         mc_overview_dialog_page->setLayout(mc_overview_gridlayout);
 
         //Label (header)
-        mc_overview_header_label = new QLabel("<h3>Overview of Transactions</h3>", 0);
+        mc_overview_header_label = new QLabel(QString("<h3>%1</h3>").arg(tr("Overview of Transactions")), 0);
         mc_overview_gridlayout->addWidget(mc_overview_header_label, 0,0, 1,1, Qt::AlignRight);
 
         //in/Outgoing (Pane)
@@ -40,7 +40,7 @@ void OverviewWindow::dialog()
         mc_overview_gridlayout->addWidget(mc_overview_inoutgoing_pane_holder, 1,0, 1,1);
 
         //Label (inOutgoing header)
-//      mc_overview_inoutgoing_header_label = new QLabel("<b>Incoming & Outgoing Transactions</b>");
+//      mc_overview_inoutgoing_header_label = new QLabel(tr("<b>Incoming & Outgoing Transactions</b>"));
         mc_overview_inoutgoing_header_label = new QLabel;
         mc_overview_inoutgoing_pane->addWidget(mc_overview_inoutgoing_header_label);
 

--- a/src/Widgets/requestdlg.cpp
+++ b/src/Widgets/requestdlg.cpp
@@ -146,7 +146,7 @@ bool MTRequestDlg::requestFunds(QString memo, QString qstr_amount)
     }
     // ----------------------------------------------------
     if (memo.isEmpty())
-        memo = QString("From the desktop client. (Empty memo.)");
+        memo = tr("From the desktop client. (Empty memo.)");
     // ----------------------------------------------------
     if (qstr_amount.isEmpty())
         qstr_amount = QString("0");
@@ -193,16 +193,16 @@ void MTRequestDlg::on_requestButton_clicked()
     // From:
     if (m_hisNymId.isEmpty())
     {
-        QMessageBox::warning(this, QString("No Invoicee"),
-                             QString("Please choose an invoicee for the request."));
+        QMessageBox::warning(this, tr("No Invoicee"),
+                             tr("Please choose an invoicee for the request."));
         return;
     }
     // -----------------------------------------------------------------
     // To:
     if (m_myAcctId.isEmpty())
     {
-        QMessageBox::warning(this, QString("No Payee Account"),
-                             QString("Please choose an account to receive the funds into."));
+        QMessageBox::warning(this, tr("No Payee Account"),
+                             tr("Please choose an account to receive the funds into."));
         return;
     }
     // -----------------------------------------------------------------
@@ -211,7 +211,7 @@ void MTRequestDlg::on_requestButton_clicked()
     {
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "The memo is blank. Are you sure you want to request?",
+        reply = QMessageBox::question(this, "", tr("The memo is blank. Are you sure you want to request?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::No)
           return;
@@ -220,8 +220,8 @@ void MTRequestDlg::on_requestButton_clicked()
     // Amount:
     if (ui->amountEdit->text().isEmpty())
     {
-        QMessageBox::warning(this, QString("Amount is Empty"),
-                             QString("Please enter the amount you wish to request."));
+        QMessageBox::warning(this, tr("Amount is Empty"),
+                             tr("Please enter the amount you wish to request."));
         return;
     }
     // -----------------------------------------------------------------
@@ -247,8 +247,8 @@ void MTRequestDlg::on_requestButton_clicked()
     }
     // -----------------------------------------------------------------
     if (!bSent)
-        QMessageBox::warning(this, QString("Failed Requesting Funds"),
-                             QString("Failed trying to send invoice."));
+        QMessageBox::warning(this, tr("Failed Requesting Funds"),
+                             tr("Failed trying to send invoice."));
     else
         this->close();
     // -----------------------------------------------------------------
@@ -292,7 +292,7 @@ void MTRequestDlg::on_toButton_clicked()
     if (bFoundDefault && !m_myAcctId.isEmpty())
         theChooser.SetPreSelected(m_myAcctId);
     // -----------------------------------------------
-    theChooser.setWindowTitle("Select your Payee Account");
+    theChooser.setWindowTitle(tr("Select your Payee Account"));
     // -----------------------------------------------
     if (theChooser.exec() == QDialog::Accepted)
     {
@@ -316,7 +316,7 @@ void MTRequestDlg::on_toButton_clicked()
     }
     // -----------------------------------------------
     m_myAcctId = QString("");
-    ui->toButton->setText("<Click to choose Account>");
+    ui->toButton->setText(tr("<Click to choose Account>"));
 }
 
 
@@ -342,7 +342,7 @@ void MTRequestDlg::on_fromButton_clicked()
         }
     }
     // -----------------------------------------------
-    theChooser.setWindowTitle("Choose the Invoicee");
+    theChooser.setWindowTitle(tr("Choose the Invoicee"));
     // -----------------------------------------------
     if (theChooser.exec() == QDialog::Accepted)
     {
@@ -365,7 +365,7 @@ void MTRequestDlg::on_fromButton_clicked()
             {
                 qstrContactName  = QString("");
                 m_hisNymId = QString("");
-                ui->fromButton->setText("<Click to Choose Invoicee>");
+                ui->fromButton->setText(tr("<Click to Choose Invoicee>"));
                 return;
             }
             // else...
@@ -373,7 +373,7 @@ void MTRequestDlg::on_fromButton_clicked()
             qstrContactName = MTContactHandler::getInstance()->GetContactName(nSelectedContactID);
 
             if (qstrContactName.isEmpty())
-                ui->fromButton->setText("(Contact has a blank name)");
+                ui->fromButton->setText(tr("(Contact has a blank name)"));
             else
                 ui->fromButton->setText(qstrContactName);
             // ---------------------------------------------
@@ -397,10 +397,10 @@ void MTRequestDlg::on_fromButton_clicked()
                     else
                     {
                         m_hisNymId = QString("");
-                        ui->fromButton->setText("<Click to Choose Invoicee>");
+                        ui->fromButton->setText(tr("<Click to Choose Invoicee>"));
                         // -------------------------------------
-                        QMessageBox::warning(this, QString("Contact has no known identities"),
-                                             QString("Sorry, Contact '%1' has no known NymIDs (to request funds from.)").arg(qstrContactName));
+                        QMessageBox::warning(this, tr("Contact has no known identities"),
+                                             tr("Sorry, Contact '%1' has no known NymIDs (to request funds from.)").arg(qstrContactName));
                         return;
                     }
                 }
@@ -408,24 +408,24 @@ void MTRequestDlg::on_fromButton_clicked()
                 {
                     DlgChooser theNymChooser(this);
                     theNymChooser.m_map = theNymMap;
-                    theNymChooser.setWindowTitle("Invoicee has multiple Nyms. (Please choose one.)");
+                    theNymChooser.setWindowTitle(tr("Invoicee has multiple Nyms. (Please choose one.)"));
                     // -----------------------------------------------
                     if (theNymChooser.exec() == QDialog::Accepted)
                         m_hisNymId = theNymChooser.m_qstrCurrentID;
                     else // User must have cancelled.
                     {
                         m_hisNymId = QString("");
-                        ui->fromButton->setText("<Click to Choose Invoicee>");
+                        ui->fromButton->setText(tr("<Click to Choose Invoicee>"));
                     }
                 }
             }
             else // No nyms found for this ContactID.
             {
                 m_hisNymId = QString("");
-                ui->fromButton->setText("<Click to Choose Invoicee>");
+                ui->fromButton->setText(tr("<Click to Choose Invoicee>"));
                 // -------------------------------------
-                QMessageBox::warning(this, QString("Contact has no known identities"),
-                                     QString("Sorry, Contact '%1' has no known NymIDs (to request funds from.)").arg(qstrContactName));
+                QMessageBox::warning(this, tr("Contact has no known identities"),
+                                     tr("Sorry, Contact '%1' has no known NymIDs (to request funds from.)").arg(qstrContactName));
                 return;
             }
             // --------------------------------
@@ -447,7 +447,7 @@ void MTRequestDlg::dialog()
 
     if (!already_init)
     {
-        this->setWindowTitle("Request Funds");
+        this->setWindowTitle(tr("Request Funds"));
 
         QString style_sheet = "QPushButton{border: none; border-style: outset; text-align:left; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,stop: 0 #dadbde, stop: 1 #f6f7fa);}"
                 "QPushButton:pressed {border: 1px solid black; text-align:left; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,stop: 0 #dadbde, stop: 1 #f6f7fa); }"
@@ -475,7 +475,7 @@ void MTRequestDlg::dialog()
         if (str_my_name.empty())
         {
             m_myAcctId = QString("");
-            ui->toButton->setText(QString("<Click to Select Payee Account>"));
+            ui->toButton->setText(tr("<Click to Select Payee Account>"));
         }
         else
             ui->toButton->setText(QString::fromStdString(str_my_name));
@@ -498,7 +498,7 @@ void MTRequestDlg::dialog()
         if (str_his_name.empty())
         {
             m_hisNymId = QString("");
-            ui->fromButton->setText("<Click to Choose Invoicee>");
+            ui->fromButton->setText(tr("<Click to Choose Invoicee>"));
         }
         else
             ui->fromButton->setText(QString::fromStdString(str_his_name));
@@ -512,7 +512,7 @@ void MTRequestDlg::dialog()
             QString qstrTemp = m_memo;
             ui->memoEdit->setText(qstrTemp);
             // -----------------------
-            this->setWindowTitle(QString("Request Funds | Memo: %1").arg(qstrTemp));
+            this->setWindowTitle(QString("%1 %2").arg(tr("Request Funds | Memo:")).arg(qstrTemp));
         }
         // -------------------------------------------
 
@@ -567,12 +567,12 @@ void MTRequestDlg::on_memoEdit_textChanged(const QString &arg1)
     if (arg1.isEmpty())
     {
         m_memo = QString("");
-        this->setWindowTitle(QString("Request Funds"));
+        this->setWindowTitle(tr("Request Funds"));
     }
     else
     {
         m_memo = arg1;
-        this->setWindowTitle(QString("Request Funds | Memo: %1").arg(arg1));
+        this->setWindowTitle(QString("%1 %2").arg(tr("Request Funds | Memo:")).arg(arg1));
     }
 }
 
@@ -606,7 +606,7 @@ void MTRequestDlg::closeEvent(QCloseEvent *event)
     {
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "Close without requesting funds?",
+        reply = QMessageBox::question(this, "", tr("Close without requesting funds?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply != QMessageBox::Yes)
         {

--- a/src/Widgets/requestfundswindow.cpp
+++ b/src/Widgets/requestfundswindow.cpp
@@ -17,7 +17,7 @@ void RequestFundsWindow::dialog()
         requestfunds_gridlayout = new QGridLayout(0);
         requestfunds_dialog->setLayout(requestfunds_gridlayout);
         //Set window title
-        requestfunds_dialog->setWindowTitle("Request Payment | Moneychanger");
+        requestfunds_dialog->setWindowTitle(tr("Request Payment | Moneychanger"));
         
         //Content
 //        //Select requestfunds type

--- a/src/Widgets/senddlg.cpp
+++ b/src/Widgets/senddlg.cpp
@@ -109,7 +109,7 @@ bool MTSendDlg::sendCash(int64_t amount, QString toNymId, QString fromAcctId, QS
     }
     // ------------------------------------------------------------
     if (note.isEmpty())
-        note = QString("From the Qt systray app.");
+        note = tr("From the Qt systray app.");
     // ------------------------------------------------------------
     std::string str_toNymId   (toNymId   .toStdString());
     std::string str_fromAcctId(fromAcctId.toStdString());
@@ -185,7 +185,7 @@ bool MTSendDlg::sendCashierCheque(int64_t amount, QString toNymId, QString fromA
         return false;
     }
     if (note.isEmpty())
-        note = QString("From the desktop systray app.");
+        note = tr("From the desktop systray app.");
     // ------------------------------------------------------------
     std::string str_toNymId   (toNymId   .toStdString());
     std::string str_fromAcctId(fromAcctId.toStdString());
@@ -367,7 +367,7 @@ bool MTSendDlg::sendChequeLowLevel(int64_t amount, QString toNymId, QString from
     // Also of course, in the case of invoices, your account balance is irrelevant
     // since an invoice can only increase your balance, not decrease it.
     if (note.isEmpty())
-        note = QString("From the Qt systray app.");
+        note = tr("From the Qt systray app.");
     // ------------------------------------------------------------
     std::string str_toNymId   (toNymId   .toStdString());
     std::string str_fromAcctId(fromAcctId.toStdString());
@@ -457,7 +457,7 @@ bool MTSendDlg::sendFunds(QString memo, QString qstr_amount)
     }
     // ----------------------------------------------------
     if (memo.isEmpty())
-        memo = QString("From the desktop client. (Empty memo.)");
+        memo = tr("From the desktop client. (Empty memo.)");
     // ----------------------------------------------------
     if (qstr_amount.isEmpty())
         qstr_amount = QString("0");
@@ -521,16 +521,16 @@ void MTSendDlg::on_sendButton_clicked()
     // To:
     if (m_hisNymId.isEmpty())
     {
-        QMessageBox::warning(this, QString("No Recipient Selected"),
-                             QString("Please choose a recipient for these funds, before sending."));
+        QMessageBox::warning(this, tr("No Recipient Selected"),
+                             tr("Please choose a recipient for these funds, before sending."));
         return;
     }
     // -----------------------------------------------------------------
     // From:
     if (m_myAcctId.isEmpty())
     {
-        QMessageBox::warning(this, QString("No Sender Account Selected"),
-                             QString("Please choose an account where the funds will come out of."));
+        QMessageBox::warning(this, tr("No Sender Account Selected"),
+                             tr("Please choose an account where the funds will come out of."));
         return;
     }
     // -----------------------------------------------------------------
@@ -539,7 +539,7 @@ void MTSendDlg::on_sendButton_clicked()
     {
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "The memo is blank. Are you sure you want to send?",
+        reply = QMessageBox::question(this, "", tr("The memo is blank. Are you sure you want to send?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::No)
           return;
@@ -548,8 +548,8 @@ void MTSendDlg::on_sendButton_clicked()
     // Amount:
     if (ui->amountEdit->text().isEmpty())
     {
-        QMessageBox::warning(this, QString("Amount is Empty"),
-                             QString("Please enter the amount you wish to send."));
+        QMessageBox::warning(this, tr("Amount is Empty"),
+                             tr("Please enter the amount you wish to send."));
         return;
     }
     // -----------------------------------------------------------------
@@ -575,8 +575,8 @@ void MTSendDlg::on_sendButton_clicked()
     }
     // -----------------------------------------------------------------
     if (!bSent)
-        QMessageBox::warning(this, QString("Failed Sending Funds"),
-                             QString("Failed trying to send funds."));
+        QMessageBox::warning(this, tr("Failed Sending Funds"),
+                             tr("Failed trying to send funds."));
     else
         this->close();
     // -----------------------------------------------------------------
@@ -613,7 +613,7 @@ QString MTSendDlg::FormDisplayLabelForAcctButton(QString qstr_acct_id, QString q
         int64_t  raw_cash_balance = this->rawCashBalance(qstr_acct_server, qstr_acct_asset, qstr_acct_nym);
 
         if (raw_cash_balance > 0)
-            from_button_text += QString(" + %1 in cash").arg(cashBalance(qstr_acct_server, qstr_acct_asset, qstr_acct_nym));
+            from_button_text += tr(" + %1 in cash").arg(cashBalance(qstr_acct_server, qstr_acct_asset, qstr_acct_nym));
     }
     // --------------------------------------------
     from_button_text += QString(")");
@@ -657,7 +657,7 @@ void MTSendDlg::on_fromButton_clicked()
     if (bFoundDefault && !m_myAcctId.isEmpty())
         theChooser.SetPreSelected(m_myAcctId);
     // -----------------------------------------------
-    theChooser.setWindowTitle("Select the Source Account");
+    theChooser.setWindowTitle(tr("Select the Source Account"));
     // -----------------------------------------------
     if (theChooser.exec() == QDialog::Accepted)
     {
@@ -688,7 +688,7 @@ void MTSendDlg::on_fromButton_clicked()
     }
     // -----------------------------------------------
     m_myAcctId = QString("");
-    ui->fromButton->setText("<Click to choose Account>");
+    ui->fromButton->setText(tr("<Click to choose Account>"));
 }
 
 
@@ -714,7 +714,7 @@ void MTSendDlg::on_toButton_clicked()
         }
     }
     // -----------------------------------------------
-    theChooser.setWindowTitle("Choose the Recipient");
+    theChooser.setWindowTitle(tr("Choose the Recipient"));
     // -----------------------------------------------
     if (theChooser.exec() == QDialog::Accepted)
     {
@@ -737,7 +737,7 @@ void MTSendDlg::on_toButton_clicked()
             {
                 qstrContactName  = QString("");
                 m_hisNymId = QString("");
-                ui->toButton->setText("<Click to Choose Recipient>");
+                ui->toButton->setText(tr("<Click to Choose Recipient>"));
                 return;
             }
             // else...
@@ -745,7 +745,7 @@ void MTSendDlg::on_toButton_clicked()
             qstrContactName = MTContactHandler::getInstance()->GetContactName(nSelectedContactID);
 
             if (qstrContactName.isEmpty())
-                ui->toButton->setText("(Contact has a blank name)");
+                ui->toButton->setText(tr("(Contact has a blank name)"));
             else
                 ui->toButton->setText(qstrContactName);
             // ---------------------------------------------
@@ -769,10 +769,10 @@ void MTSendDlg::on_toButton_clicked()
                     else
                     {
                         m_hisNymId = QString("");
-                        ui->toButton->setText("<Click to Choose Recipient>");
+                        ui->toButton->setText(tr("<Click to Choose Recipient>"));
                         // -------------------------------------
-                        QMessageBox::warning(this, QString("Contact has no known identities"),
-                                             QString("Sorry, Contact '%1' has no known NymIDs (to send funds to.)").arg(qstrContactName));
+                        QMessageBox::warning(this, tr("Contact has no known identities"),
+                                             tr("Sorry, Contact '%1' has no known NymIDs (to send funds to.)").arg(qstrContactName));
                         return;
                     }
                 }
@@ -780,24 +780,24 @@ void MTSendDlg::on_toButton_clicked()
                 {
                     DlgChooser theNymChooser(this);
                     theNymChooser.m_map = theNymMap;
-                    theNymChooser.setWindowTitle("Recipient has multiple Nyms. (Please choose one.)");
+                    theNymChooser.setWindowTitle(tr("Recipient has multiple Nyms. (Please choose one.)"));
                     // -----------------------------------------------
                     if (theNymChooser.exec() == QDialog::Accepted)
                         m_hisNymId = theNymChooser.m_qstrCurrentID;
                     else // User must have cancelled.
                     {
                         m_hisNymId = QString("");
-                        ui->toButton->setText("<Click to Choose Recipient>");
+                        ui->toButton->setText(tr("<Click to Choose Recipient>"));
                     }
                 }
             }
             else // No nyms found for this ContactID.
             {
                 m_hisNymId = QString("");
-                ui->toButton->setText("<Click to Choose Recipient>");
+                ui->toButton->setText(tr("<Click to Choose Recipient>"));
                 // -------------------------------------
-                QMessageBox::warning(this, QString("Contact has no known identities"),
-                                     QString("Sorry, Contact '%1' has no known NymIDs (to send funds to.)").arg(qstrContactName));
+                QMessageBox::warning(this, tr("Contact has no known identities"),
+                                     tr("Sorry, Contact '%1' has no known NymIDs (to send funds to.)").arg(qstrContactName));
                 return;
             }
             // --------------------------------
@@ -819,7 +819,7 @@ void MTSendDlg::dialog()
 
     if (!already_init)
     {
-        this->setWindowTitle("Send Funds");
+        this->setWindowTitle(tr("Send Funds"));
 
         QString style_sheet = "QPushButton{border: none; border-style: outset; text-align:left; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,stop: 0 #dadbde, stop: 1 #f6f7fa);}"
                 "QPushButton:pressed {border: 1px solid black; text-align:left; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,stop: 0 #dadbde, stop: 1 #f6f7fa); }"
@@ -847,7 +847,7 @@ void MTSendDlg::dialog()
         if (str_my_name.empty())
         {
             m_myAcctId = QString("");
-            ui->fromButton->setText(QString("<Click to Select Account>"));
+            ui->fromButton->setText(tr("<Click to Select Account>"));
         }
         else
         {
@@ -874,7 +874,7 @@ void MTSendDlg::dialog()
         if (str_his_name.empty())
         {
             m_hisNymId = QString("");
-            ui->toButton->setText("<Click to Choose Recipient>");
+            ui->toButton->setText(tr("<Click to Choose Recipient>"));
         }
         else
             ui->toButton->setText(QString::fromStdString(str_his_name));
@@ -888,7 +888,7 @@ void MTSendDlg::dialog()
             QString qstrTemp = m_memo;
             ui->memoEdit->setText(qstrTemp);
             // -----------------------
-            this->setWindowTitle(QString("Send Funds | Memo: %1").arg(qstrTemp));
+            this->setWindowTitle(tr("Send Funds | Memo: %1").arg(qstrTemp));
         }
         // -------------------------------------------
 
@@ -943,12 +943,12 @@ void MTSendDlg::on_memoEdit_textChanged(const QString &arg1)
     if (arg1.isEmpty())
     {
         m_memo = QString("");
-        this->setWindowTitle(QString("Send Funds"));
+        this->setWindowTitle(tr("Send Funds"));
     }
     else
     {
         m_memo = arg1;
-        this->setWindowTitle(QString("Send Funds | Memo: %1").arg(arg1));
+        this->setWindowTitle(tr("Send Funds | Memo: %1").arg(arg1));
     }
 }
 
@@ -982,7 +982,7 @@ void MTSendDlg::closeEvent(QCloseEvent *event)
     {
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "Close without sending?",
+        reply = QMessageBox::question(this, "", tr("Close without sending?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply != QMessageBox::Yes)
         {

--- a/src/Widgets/sendfundswindow.cpp
+++ b/src/Widgets/sendfundswindow.cpp
@@ -17,17 +17,17 @@ void SendFundsWindow::dialog()
         sendfunds_gridlayout = new QGridLayout(0);
         sendfunds_dialog->setLayout(sendfunds_gridlayout);
         //Set window title
-        sendfunds_dialog->setWindowTitle("Send Funds | Moneychanger");
+        sendfunds_dialog->setWindowTitle(tr("Send Funds | Moneychanger"));
         
         //Content
         //Select sendfunds type
         sendfunds_sendtype_combobox = new QComboBox(0);
         sendfunds_sendtype_combobox->setStyleSheet("QComboBox{font-size:15pt;}");
         //Add selection options
-        sendfunds_sendtype_combobox->addItem("Send a Payment");
-        sendfunds_sendtype_combobox->addItem("Send a Cheque");
-        sendfunds_sendtype_combobox->addItem("Send Cash");
-        sendfunds_sendtype_combobox->addItem("Send an Account Transfer");
+        sendfunds_sendtype_combobox->addItem(tr("Send a Payment"));
+        sendfunds_sendtype_combobox->addItem(tr("Send a Cheque"));
+        sendfunds_sendtype_combobox->addItem(tr("Send Cash"));
+        sendfunds_sendtype_combobox->addItem(tr("Send an Account Transfer"));
         
         sendfunds_gridlayout->addWidget(sendfunds_sendtype_combobox, 0,0, 1,1, Qt::AlignHCenter);
         already_init = true;

--- a/src/Widgets/serverdetails.cpp
+++ b/src/Widgets/serverdetails.cpp
@@ -76,15 +76,15 @@ void MTServerDetails::DeleteButtonClicked()
 
         if (!bCanRemove)
         {
-            QMessageBox::warning(this, QString("Server Cannot Be Deleted"),
-                                 QString("This Server cannot be deleted yet, since you probably have Nyms registered there. "
+            QMessageBox::warning(this, tr("Server Cannot Be Deleted"),
+                                 tr("This Server cannot be deleted yet, since you probably have Nyms registered there. "
                                          "(This is where, in the future, you'd be given the option to automatically delete those Nyms.)"));
             return;
         }
         // ----------------------------------------------------
         QMessageBox::StandardButton reply;
 
-        reply = QMessageBox::question(this, "", "Are you sure you want to remove this Server Contract?",
+        reply = QMessageBox::question(this, "", tr("Are you sure you want to remove this Server Contract?"),
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::Yes)
         {
@@ -96,8 +96,8 @@ void MTServerDetails::DeleteButtonClicked()
                 m_pOwner->RefreshRecords();
             }
             else
-                QMessageBox::warning(this, QString("Failure Removing Server Contract"),
-                                     QString("Failed trying to remove this Server Contract."));
+                QMessageBox::warning(this, tr("Failure Removing Server Contract"),
+                                     tr("Failed trying to remove this Server Contract."));
         }
     }
     // ----------------------------------------------------

--- a/src/Widgets/withdrawascashwindow.cpp
+++ b/src/Widgets/withdrawascashwindow.cpp
@@ -24,7 +24,7 @@ void WithdrawAsCashWindow::dialog()
         withdraw_ascash_dialog->installEventFilter(this);
         /** window properties **/
         //Set window title
-        withdraw_ascash_dialog->setWindowTitle("Withdraw as Cash | Moneychanger");
+        withdraw_ascash_dialog->setWindowTitle(tr("Withdraw as Cash | Moneychanger"));
         //withdraw_ascash_dialog->setWindowFlags(Qt::WindowStaysOnTopHint);
 
         /** layout and content **/
@@ -33,7 +33,7 @@ void WithdrawAsCashWindow::dialog()
         withdraw_ascash_dialog->setLayout(withdraw_ascash_gridlayout);
 
         //Withdraw As Cash (header label)
-        withdraw_ascash_header_label = new QLabel("<h3>Withdraw as Cash</h3>", 0);
+        withdraw_ascash_header_label = new QLabel(QString("<h3>%1</h3>").arg(tr("Withdraw as Cash")), 0);
         withdraw_ascash_header_label->setAlignment(Qt::AlignRight);
         withdraw_ascash_gridlayout->addWidget(withdraw_ascash_header_label, 0, 0, 1, 1);
 
@@ -56,12 +56,12 @@ void WithdrawAsCashWindow::dialog()
 
         //Amount Input
         withdraw_ascash_amount_input = new QLineEdit;
-        withdraw_ascash_amount_input->setPlaceholderText("Amount");
+        withdraw_ascash_amount_input->setPlaceholderText(tr("Amount"));
         withdraw_ascash_amount_input->setStyleSheet("QLineEdit{padding:0.5em;}");
         withdraw_ascash_gridlayout->addWidget(withdraw_ascash_amount_input, 3, 0, 1, 1);
 
         //Withdraw Button
-        withdraw_ascash_button = new QPushButton("Withdraw as Cash");
+        withdraw_ascash_button = new QPushButton(tr("Withdraw as Cash"));
         withdraw_ascash_button->setStyleSheet("QPushButton{padding:0.5em;}");
         withdraw_ascash_gridlayout->addWidget(withdraw_ascash_button, 4, 0, 1, 1);
         //Connect button with re-action
@@ -110,7 +110,7 @@ void WithdrawAsCashWindow::withdraw_ascash_confirm_amount_dialog_slot(){
         withdraw_ascash_confirm_dialog->setLayout(withdraw_ascash_confirm_gridlayout);
         
         //Ask the operator to confirm the amount requested
-        withdraw_ascash_confirm_label = new QLabel("Please confirm the amount to withdraw.");
+        withdraw_ascash_confirm_label = new QLabel(tr("Please confirm the amount to withdraw."));
         withdraw_ascash_confirm_gridlayout->addWidget(withdraw_ascash_confirm_label, 0,0, 1,1);
         
         //Label (Amount)
@@ -132,13 +132,13 @@ void WithdrawAsCashWindow::withdraw_ascash_confirm_amount_dialog_slot(){
         withdraw_ascash_confirm_gridlayout->addWidget(withdraw_ascash_confirm_amount_confirm_cancel_widget, 3, 0, 1, 1);
         
         //Button (Cancel amount)
-        withdraw_ascash_confirm_amount_btn_cancel = new QPushButton("Cancel Amount", 0);
+        withdraw_ascash_confirm_amount_btn_cancel = new QPushButton(tr("Cancel Amount"), 0);
         withdraw_ascash_confirm_amount_confirm_cancel_layout->addWidget(withdraw_ascash_confirm_amount_btn_cancel);
         //Connect the cancel button with a re-action
         connect(withdraw_ascash_confirm_amount_btn_cancel, SIGNAL(clicked()), this, SLOT(withdraw_ascash_cancel_amount_slot()));
         
         //Button (Confirm amount)
-        withdraw_ascash_confirm_amount_btn_confirm = new QPushButton("Confirm Amount", 0);
+        withdraw_ascash_confirm_amount_btn_confirm = new QPushButton(tr("Confirm Amount"), 0);
         withdraw_ascash_confirm_amount_confirm_cancel_layout->addWidget(withdraw_ascash_confirm_amount_btn_confirm);
         //Connect the Confirm button with a re-action
         connect(withdraw_ascash_confirm_amount_btn_confirm, SIGNAL(clicked()), this, SLOT(withdraw_ascash_confirm_amount_slot()));

--- a/src/Widgets/withdrawasvoucherwindow.cpp
+++ b/src/Widgets/withdrawasvoucherwindow.cpp
@@ -25,7 +25,7 @@ void WithdrawAsVoucherWindow::dialog()
         withdraw_asvoucher_dialog->installEventFilter(this);
         /** window properties **/
         //Set window title
-        withdraw_asvoucher_dialog->setWindowTitle("Withdraw as Voucher | Moneychanger");
+        withdraw_asvoucher_dialog->setWindowTitle(tr("Withdraw as Voucher | Moneychanger"));
         //withdraw_asvoucher_dialog->setWindowFlags(Qt::WindowStaysOnTopHint);
         
         /** layout and content **/
@@ -34,7 +34,7 @@ void WithdrawAsVoucherWindow::dialog()
         withdraw_asvoucher_dialog->setLayout(withdraw_asvoucher_gridlayout);
         
         //Label (withdraw as voucher)
-        withdraw_asvoucher_header_label = new QLabel("<h3>Withdraw as Voucher</h3>", 0);
+        withdraw_asvoucher_header_label = new QLabel(QString("<h3>%1</h3>").arg(tr("Withdraw as Voucher")), 0);
         withdraw_asvoucher_header_label->setAlignment(Qt::AlignRight);
         withdraw_asvoucher_gridlayout->addWidget(withdraw_asvoucher_header_label, 0,0, 1,1);
         
@@ -62,7 +62,7 @@ void WithdrawAsVoucherWindow::dialog()
         
         //Nym ID (Paste input)
         withdraw_asvoucher_nym_input = new QLineEdit;
-        withdraw_asvoucher_nym_input->setPlaceholderText("Recipient Nym Id");
+        withdraw_asvoucher_nym_input->setPlaceholderText(tr("Recipient Nym Id"));
         withdraw_asvoucher_nym_input->setStyleSheet("QLineEdit{padding:0.5em;}");
         withdraw_asvoucher_nym_hbox->addWidget(withdraw_asvoucher_nym_input);
         
@@ -81,16 +81,16 @@ void WithdrawAsVoucherWindow::dialog()
         
         //Amount input
         withdraw_asvoucher_amount_input = new QLineEdit;
-        withdraw_asvoucher_amount_input->setPlaceholderText("Amount as Integer");
+        withdraw_asvoucher_amount_input->setPlaceholderText(tr("Amount as Integer"));
         withdraw_asvoucher_amount_input->setStyleSheet("QLineEdit{padding:0.5em;}");
         withdraw_asvoucher_gridlayout->addWidget(withdraw_asvoucher_amount_input, 4,0, 1,1);
         
         //Memo input box
-        withdraw_asvoucher_memo_input = new QTextEdit("Memo", 0);
+        withdraw_asvoucher_memo_input = new QTextEdit(tr("Memo"), 0);
         withdraw_asvoucher_gridlayout->addWidget(withdraw_asvoucher_memo_input, 5,0, 1,1);
         
         //Withdraw Button
-        withdraw_asvoucher_button = new QPushButton("Withdraw as Voucher");
+        withdraw_asvoucher_button = new QPushButton(tr("Withdraw as Voucher"));
         withdraw_asvoucher_button->setStyleSheet("QPushButton{padding:1em;}");
         withdraw_asvoucher_gridlayout->addWidget(withdraw_asvoucher_button, 6,0, 1,1);
         //Connect button with re-action
@@ -149,7 +149,7 @@ void WithdrawAsVoucherWindow::confirm_amount_dialog_slot(){
         
         //Ask the operator to confirm the amount
         //Ask Label
-        withdraw_asvoucher_confirm_label = new QLabel("<h3>Please confirm the amount to withdraw.</h3>", 0);
+        withdraw_asvoucher_confirm_label = new QLabel(QString("<h3>%1</h3>").arg(tr("Please confirm the amount to withdraw.")), 0);
         withdraw_asvoucher_confirm_label->setAlignment(Qt::AlignRight);
         withdraw_asvoucher_confirm_gridlayout->addWidget(withdraw_asvoucher_confirm_label, 0,0, 1,1);
         
@@ -175,13 +175,13 @@ void WithdrawAsVoucherWindow::confirm_amount_dialog_slot(){
         
         
         //Button (Cancel amount)
-        withdraw_asvoucher_confirm_amount_btn_cancel = new QPushButton("Cancel Amount", 0);
+        withdraw_asvoucher_confirm_amount_btn_cancel = new QPushButton(tr("Cancel Amount"), 0);
         withdraw_asvoucher_confirm_amount_confirm_cancel_layout->addWidget(withdraw_asvoucher_confirm_amount_btn_cancel);
         //Connect the cancel button with a re-action
         connect(withdraw_asvoucher_confirm_amount_btn_cancel, SIGNAL(clicked()), this, SLOT(cancel_amount_slot()));
         
         //Button (Confirm amount)
-        withdraw_asvoucher_confirm_amount_btn_confirm = new QPushButton("Confirm Amount", 0);
+        withdraw_asvoucher_confirm_amount_btn_confirm = new QPushButton(tr("Confirm Amount"), 0);
         withdraw_asvoucher_confirm_amount_confirm_cancel_layout->addWidget(withdraw_asvoucher_confirm_amount_btn_confirm);
         //Connect the Confirm button with a re-action
         connect(withdraw_asvoucher_confirm_amount_btn_confirm, SIGNAL(clicked()), this, SLOT(confirm_amount_slot()));

--- a/src/moneychanger.cpp
+++ b/src/moneychanger.cpp
@@ -258,7 +258,7 @@ Moneychanger::Moneychanger(QWidget *parent)
     
     //Init Skeleton of system tray menu
     //App name
-    mc_systrayMenu_headertext = new QAction("Moneychanger", 0);
+    mc_systrayMenu_headertext = new QAction(tr("Moneychanger"), 0);
     mc_systrayMenu_headertext->setDisabled(1);
     mc_systrayMenu->addAction(mc_systrayMenu_headertext);
     // --------------------------------------------------------------
@@ -271,7 +271,7 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu->addSeparator();
     // --------------------------------------------------------------
     //Overview button
-    mc_systrayMenu_overview = new QAction(mc_systrayIcon_overview, "Transaction History", 0);
+    mc_systrayMenu_overview = new QAction(mc_systrayIcon_overview, tr("Transaction History"), 0);
     mc_systrayMenu->addAction(mc_systrayMenu_overview);
     //Connect the Overview to a re-action when "clicked";
     connect(mc_systrayMenu_overview, SIGNAL(triggered()), this, SLOT(mc_overview_slot()));
@@ -280,13 +280,13 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu->addSeparator();
     // --------------------------------------------------------------
     //Send funds
-    mc_systrayMenu_sendfunds = new QAction(mc_systrayIcon_sendfunds, "Send Funds...", 0);
+    mc_systrayMenu_sendfunds = new QAction(mc_systrayIcon_sendfunds, tr("Send Funds..."), 0);
     mc_systrayMenu->addAction(mc_systrayMenu_sendfunds);
     //Connect button with re-aciton
     connect(mc_systrayMenu_sendfunds, SIGNAL(triggered()), this, SLOT(mc_sendfunds_slot()));
     // --------------------------------------------------------------
     //Request payment
-    mc_systrayMenu_requestfunds = new QAction(mc_systrayIcon_requestfunds, "Request Payment...", 0);
+    mc_systrayMenu_requestfunds = new QAction(mc_systrayIcon_requestfunds, tr("Request Payment..."), 0);
     mc_systrayMenu->addAction(mc_systrayMenu_requestfunds);
     // Currently causes a crash , likely due to malformed Dialog construction.
     connect(mc_systrayMenu_requestfunds, SIGNAL(triggered()), this, SLOT(mc_requestfunds_slot()));
@@ -295,12 +295,12 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu->addSeparator();
     // --------------------------------------------------------------
     //Account section
-    mc_systrayMenu_account = new QMenu("Set Default Account...", 0);
+    mc_systrayMenu_account = new QMenu(tr("Set Default Account..."), 0);
     mc_systrayMenu_account->setIcon(mc_systrayIcon_goldaccount);
     mc_systrayMenu->addMenu(mc_systrayMenu_account);
     
     //Add a "Manage accounts" action button (and connection)
-    QAction * manage_accounts = new QAction("Manage Accounts...", 0);
+    QAction * manage_accounts = new QAction(tr("Manage Accounts..."), 0);
     manage_accounts->setData(QVariant(QString("openmanager")));
     mc_systrayMenu_account->addAction(manage_accounts);
     mc_systrayMenu_account->addSeparator();
@@ -318,12 +318,12 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu_reload_accountlist();
     // --------------------------------------------------------------
     //Asset section
-    mc_systrayMenu_asset = new QMenu("Set Default Asset Type...", 0);
+    mc_systrayMenu_asset = new QMenu(tr("Set Default Asset Type..."), 0);
     mc_systrayMenu_asset->setIcon(mc_systrayIcon_purse);
     mc_systrayMenu->addMenu(mc_systrayMenu_asset);
     
     //Add a "Manage asset types" action button (and connection)
-    QAction * manage_assets = new QAction("Manage Asset Contracts...", 0);
+    QAction * manage_assets = new QAction(tr("Manage Asset Contracts..."), 0);
     manage_assets->setData(QVariant(QString("openmanager")));
     mc_systrayMenu_asset->addAction(manage_assets);
     mc_systrayMenu_asset->addSeparator();
@@ -344,23 +344,23 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu->addSeparator();
     // --------------------------------------------------------------
     //Withdraw
-    mc_systrayMenu_withdraw = new QMenu("Withdraw", 0);
+    mc_systrayMenu_withdraw = new QMenu(tr("Withdraw"), 0);
     mc_systrayMenu_withdraw->setIcon(mc_systrayIcon_withdraw);
     mc_systrayMenu->addMenu(mc_systrayMenu_withdraw);
     //(Withdraw) as Cash
-    mc_systrayMenu_withdraw_ascash = new QAction("As Cash",0);
+    mc_systrayMenu_withdraw_ascash = new QAction(tr("As Cash"),0);
     mc_systrayMenu_withdraw->addAction(mc_systrayMenu_withdraw_ascash);
     //Connect Button with re-action
     connect(mc_systrayMenu_withdraw_ascash, SIGNAL(triggered()), this, SLOT(mc_withdraw_ascash_slot()));
     
     //(Withdraw) as Voucher
-    mc_systrayMenu_withdraw_asvoucher = new QAction("As Voucher", 0);
+    mc_systrayMenu_withdraw_asvoucher = new QAction(tr("As Voucher"), 0);
     mc_systrayMenu_withdraw->addAction(mc_systrayMenu_withdraw_asvoucher);
     //Connect Button with re-action
     connect(mc_systrayMenu_withdraw_asvoucher, SIGNAL(triggered()), this, SLOT(mc_withdraw_asvoucher_slot()));
     // --------------------------------------------------------------
     //Deposit
-    mc_systrayMenu_deposit = new QAction(mc_systrayIcon_deposit, "Deposit...", 0);
+    mc_systrayMenu_deposit = new QAction(mc_systrayIcon_deposit, tr("Deposit..."), 0);
     mc_systrayMenu->addAction(mc_systrayMenu_deposit);
     //Connect button with re-action
     connect(mc_systrayMenu_deposit, SIGNAL(triggered()), this, SLOT(mc_deposit_slot()));
@@ -389,43 +389,43 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu->addMenu(mc_systrayMenu_advanced);
     //Advanced submenu
         
-    mc_systrayMenu_advanced_markets = new QAction(mc_systrayIcon_advanced_markets, "Markets", 0);
+    mc_systrayMenu_advanced_markets = new QAction(mc_systrayIcon_advanced_markets, tr("Markets"), 0);
     mc_systrayMenu_advanced->addAction(mc_systrayMenu_advanced_markets);
     connect(mc_systrayMenu_advanced_markets, SIGNAL(triggered()), this, SLOT(mc_market_slot()));
 
-    mc_systrayMenu_advanced_agreements = new QAction(mc_systrayIcon_advanced_agreements, "Agreements", 0);
+    mc_systrayMenu_advanced_agreements = new QAction(mc_systrayIcon_advanced_agreements, tr("Agreements"), 0);
     mc_systrayMenu_advanced->addAction(mc_systrayMenu_advanced_agreements);
     // --------------------------------------------------------------
     //Separator
     mc_systrayMenu_advanced->addSeparator();
     // ------------------------------------------------
     // Corporations
-    mc_systrayMenu_advanced_corporations = new QMenu("Corporations", 0);
+    mc_systrayMenu_advanced_corporations = new QMenu(tr("Corporations"), 0);
     mc_systrayMenu_advanced->addMenu(mc_systrayMenu_advanced_corporations);
 
     // Corporations submenu
-    mc_systrayMenu_company_create = new QMenu("Create", 0);
+    mc_systrayMenu_company_create = new QMenu(tr("Create"), 0);
     mc_systrayMenu_advanced_corporations->addMenu(mc_systrayMenu_company_create);
 
     // Create insurance company action on submenu
-    mc_systrayMenu_company_create_insurance = new QAction(mc_systrayIcon_advanced_agreements, "Insurance Company", 0);
+    mc_systrayMenu_company_create_insurance = new QAction(mc_systrayIcon_advanced_agreements, tr("Insurance Company"), 0);
     mc_systrayMenu_company_create->addAction(mc_systrayMenu_company_create_insurance);
     connect(mc_systrayMenu_company_create_insurance, SIGNAL(triggered()), this, SLOT(mc_createinsurancecompany_slot()));
     // --------------------------------------------------------------
     // Bazaar
-    mc_systrayMenu_advanced_bazaar = new QMenu("Bazaar", 0);
+    mc_systrayMenu_advanced_bazaar = new QMenu(tr("Bazaar"), 0);
     mc_systrayMenu_advanced->addMenu(mc_systrayMenu_advanced_bazaar);
 
     // Bazaar actions
-    mc_systrayMenu_bazaar_search = new QAction(mc_systrayIcon_advanced_agreements, "Search Listings", 0);
+    mc_systrayMenu_bazaar_search = new QAction(mc_systrayIcon_advanced_agreements, tr("Search Listings"), 0);
     mc_systrayMenu_advanced_bazaar->addAction(mc_systrayMenu_bazaar_search);
 //  connect(mc_systrayMenu_bazaar_search, SIGNAL(triggered()), this, SLOT(mc_bazaar_search_slot()));
 
-    mc_systrayMenu_bazaar_post = new QAction(mc_systrayIcon_advanced_agreements, "Post an Ad", 0);
+    mc_systrayMenu_bazaar_post = new QAction(mc_systrayIcon_advanced_agreements, tr("Post an Ad"), 0);
     mc_systrayMenu_advanced_bazaar->addAction(mc_systrayMenu_bazaar_post);
 //  connect(mc_systrayMenu_bazaar_post, SIGNAL(triggered()), this, SLOT(mc_bazaar_search_slot()));
 
-    mc_systrayMenu_bazaar_orders = new QAction(mc_systrayIcon_advanced_agreements, "Orders", 0);
+    mc_systrayMenu_bazaar_orders = new QAction(mc_systrayIcon_advanced_agreements, tr("Orders"), 0);
     mc_systrayMenu_advanced_bazaar->addAction(mc_systrayMenu_bazaar_orders);
 //  connect(mc_systrayMenu_bazaar_orders, SIGNAL(triggered()), this, SLOT(mc_bazaar_search_slot()));
 
@@ -434,7 +434,7 @@ Moneychanger::Moneychanger(QWidget *parent)
     // -------------------------------------------------
     // Settings
     
-    mc_systrayMenu_advanced_settings = new QAction(mc_systrayIcon_advanced_settings, "Settings...", 0);
+    mc_systrayMenu_advanced_settings = new QAction(mc_systrayIcon_advanced_settings, tr("Settings..."), 0);
     mc_systrayMenu_advanced_settings->setMenuRole(QAction::NoRole);
     mc_systrayMenu_advanced->addAction(mc_systrayMenu_advanced_settings);
     // --------------------------------------------------------------
@@ -456,7 +456,7 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu_advanced->addMenu(mc_systrayMenu_nym);
     
     //Add a "Manage pseudonym" action button (and connection)
-    QAction * manage_nyms = new QAction("Manage Nyms...", 0);
+    QAction * manage_nyms = new QAction(tr("Manage Nyms..."), 0);
     manage_nyms->setData(QVariant(QString("openmanager")));
     mc_systrayMenu_nym->addAction(manage_nyms);
     mc_systrayMenu_nym->addSeparator();
@@ -474,12 +474,12 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu_reload_nymlist();
     // --------------------------------------------------------------
     //Server section
-    mc_systrayMenu_server = new QMenu("Set Default Server...", 0);
+    mc_systrayMenu_server = new QMenu(tr("Set Default Server..."), 0);
     mc_systrayMenu_server->setIcon(mc_systrayIcon_server);
     mc_systrayMenu_advanced->addMenu(mc_systrayMenu_server);
     
     //Add a "Manage server" action button (and connection)
-    QAction * manage_servers = new QAction("Manage Servers...", 0);
+    QAction * manage_servers = new QAction(tr("Manage Servers..."), 0);
     manage_servers->setData(QVariant(QString("openmanager")));
     mc_systrayMenu_server->addAction(manage_servers);
     mc_systrayMenu_server->addSeparator();
@@ -500,7 +500,7 @@ Moneychanger::Moneychanger(QWidget *parent)
     mc_systrayMenu->addSeparator();
     // --------------------------------------------------------------
     //Shutdown Moneychanger
-    mc_systrayMenu_shutdown = new QAction(mc_systrayIcon_shutdown, "Quit", 0);
+    mc_systrayMenu_shutdown = new QAction(mc_systrayIcon_shutdown, tr("Quit"), 0);
     mc_systrayMenu_shutdown->setMenuRole(QAction::NoRole);
     mc_systrayMenu_shutdown->setIcon(mc_systrayIcon_shutdown);
     mc_systrayMenu->addAction(mc_systrayMenu_shutdown);
@@ -648,7 +648,7 @@ void Moneychanger::mc_addressbook_show(QString text) // text may contain a "pre-
     MTContactHandler::getInstance()->GetContacts(contactswindow->m_map);
     // -------------------------------------
     contactswindow->SetPreSelected(text);
-    contactswindow->setWindowTitle("Contacts");
+    contactswindow->setWindowTitle(tr("Contacts"));
     // -------------------------------------
     contactswindow->dialog(MTDetailEdit::DetailEditTypeContact);
 }
@@ -704,7 +704,7 @@ void Moneychanger::mc_nymmanager_dialog()
         the_map.insert(OT_id, OT_name);
     } // for
     // -------------------------------------
-    nymswindow->setWindowTitle("Nyms");
+    nymswindow->setWindowTitle(tr("Nyms"));
     // -------------------------------------
     nymswindow->dialog(MTDetailEdit::DetailEditTypeNym);
 }
@@ -734,7 +734,7 @@ void Moneychanger::set_systrayMenu_nym_setDefaultNym(QString nym_id, QString nym
     //Rename "NYM:" if a nym is loaded
     if (nym_id != "")
     {
-        mc_systrayMenu_nym->setTitle("Nym: "+nym_name);
+        mc_systrayMenu_nym->setTitle(tr("Nym: ")+nym_name);
     }
 }
 
@@ -863,7 +863,7 @@ void Moneychanger::downloadAccountData()
 
             if (!newNymId.empty())
             {
-                OTAPI_Wrap::SetNym_Name(newNymId, newNymId, "Me");
+                OTAPI_Wrap::SetNym_Name(newNymId, newNymId, tr("Me").toLatin1().data());
                 DBHandler::getInstance()->AddressBookUpdateDefaultNym(QString::fromStdString(newNymId));
                 qDebug() << "Finished Making Nym";
             }
@@ -907,7 +907,7 @@ void Moneychanger::downloadAccountData()
                 if (accountCount > 0)
                 {
                     std::string accountID = OTAPI_Wrap::GetAccountWallet_ID(0);
-                    OTAPI_Wrap::SetAccountWallet_Name(accountID, defaultNymID, "My Acct");
+                    OTAPI_Wrap::SetAccountWallet_Name(accountID, defaultNymID, tr("My Acct").toLatin1().data());
 
                     DBHandler::getInstance()->AddressBookUpdateDefaultAccount(QString::fromStdString(accountID));
                 }
@@ -976,7 +976,7 @@ void Moneychanger::mc_assetmanager_dialog()
         the_map.insert(OT_id, OT_name);
     } // for
     // -------------------------------------
-    assetswindow->setWindowTitle("Asset Types");
+    assetswindow->setWindowTitle(tr("Asset Types"));
     // -------------------------------------
     assetswindow->dialog(MTDetailEdit::DetailEditTypeAsset);
 }
@@ -1015,7 +1015,7 @@ void Moneychanger::set_systrayMenu_asset_setDefaultAsset(QString asset_id, QStri
     
     //Rename "ASSET:" if a asset is loaded
     if(asset_id != ""){
-        mc_systrayMenu_asset->setTitle("Asset Type: "+asset_name);
+        mc_systrayMenu_asset->setTitle(tr("Asset Type: ")+asset_name);
     }
 }
 
@@ -1142,7 +1142,7 @@ void Moneychanger::mc_accountmanager_dialog()
         the_map.insert(OT_id, OT_name);
     } // for
     // -------------------------------------
-    accountswindow->setWindowTitle("Accounts");
+    accountswindow->setWindowTitle(tr("Accounts"));
     // -------------------------------------
     accountswindow->dialog(MTDetailEdit::DetailEditTypeAccount);
 }
@@ -1208,7 +1208,7 @@ void Moneychanger::set_systrayMenu_account_setDefaultAccount(QString account_id,
     
     //Rename "ACCOUNT:" if a account is loaded
     if(account_id != ""){
-        QString result = "Account: " + account_name;
+        QString result = tr("Account: ") + account_name;
         
         int64_t     lBalance = OTAPI_Wrap::GetAccountWallet_Balance(account_id.toStdString());
         std::string strAsset = OTAPI_Wrap::GetAccountWallet_AssetTypeID(account_id.toStdString());
@@ -1321,7 +1321,7 @@ void Moneychanger::mc_servermanager_dialog()
         the_map.insert(OT_id, OT_name);
     } // for
     // -------------------------------------
-    serverswindow->setWindowTitle("Server Contracts");
+    serverswindow->setWindowTitle(tr("Server Contracts"));
     // -------------------------------------
     serverswindow->dialog(MTDetailEdit::DetailEditTypeServer);
 }
@@ -1358,10 +1358,10 @@ void Moneychanger::set_systrayMenu_server_setDefaultServer(QString server_id, QS
     //Update visuals
     QString new_server_title = default_server_name;
     if(new_server_title == "" || new_server_title == " "){
-        new_server_title = "Set Default...";
+        new_server_title = tr("Set Default...");
     }
     
-    mc_systrayMenu_server->setTitle("Server: "+new_server_title);
+    mc_systrayMenu_server->setTitle(tr("Server: ")+new_server_title);
 }
 
 void Moneychanger::mc_systrayMenu_reload_serverlist()


### PR DESCRIPTION
.. for text that is visible on the user interface.

Reason:
"
The tr function is the central part of the Qt internationalization system (allso called “i18n” by people who can’t handle words with more than ten letters). That’s a system for making your application available in multiple languages.
If you want your application to have multiple language support, wrap every user-visible string in your code inside a tr() function. Then Qt will use the appropriate translated string in a different language environment. Of course Qt won’t actually translate for you, you (or your translator guy) have to do that with QtLinguist.
"
