### PR TITLE
include -std=c++11 flag for UNIX builds

### DIFF
--- a/project/common.pri
+++ b/project/common.pri
@@ -51,6 +51,7 @@ win32:{
 unix:{
     CONFIG += link_pkgconfig
     QMAKE_CXXFLAGS += -fPIC ## put only here, sub-libs pick it up from elsewhere?
+    QMAKE_CXXFLAGS += -std=c++11
 }
 
 mac:MAC_OS_VERSION = $$system(uname -r)


### PR DESCRIPTION
This fixes the immediate problem of not being able build Moneychanger on Funtoo/Gentoo.  As discussed with @randy-waterhouse in IRC, this probably is more of a work-around than a proper solution.
