### PR TITLE
Check for null messages

### DIFF
--- a/src/core/moneychanger.cpp
+++ b/src/core/moneychanger.cpp
@@ -301,7 +301,11 @@ int64_t Moneychanger::HasUsageCredits(      QWidget     * parent,
         strMessage = madeEasy.adjust_usage_credits(SERVER_ID, NYM_ID, NYM_ID, strAdjustment);
     }
     // --------------------------------------------------------
-    const int64_t lReturnValue = OTAPI_Wrap::Message_GetUsageCredits(strMessage);
+    int64_t lReturnValue;
+    if(strMessage.size() > 2)
+        lReturnValue = OTAPI_Wrap::Message_GetUsageCredits(strMessage);
+    else
+        lReturnValue = -2;
     // --------------------------------------------------------
     QString qstrErrorHeader, qstrErrorMsg;
 


### PR DESCRIPTION
This addresses the crash on the Markets window when parsing a null message.
