### PR TITLE
Mac Installation Docs Update

### DIFF
--- a/doc/INSTALL-mac.txt
+++ b/doc/INSTALL-mac.txt
@@ -16,7 +16,11 @@ $ brew install libidn
 #########
 # Open-Transactions (opentxs) requires openssl-1.0.0 or greater, so we will need to install a newer version to accomodate it
 
+$ brew tap homebrew/versions
 $ brew tap homebrew/boneyard
+$ cd /usr/local/Library/Formula/
+$ git checkout d915ce8
+$ cd -
 $ brew switch openssl 1.0.1h
 $ brew install openssl
 $ brew link --force openssl


### PR DESCRIPTION
Included full instructions for installing OpenSSL 1.0.1h as needed on Mac OSX.